### PR TITLE
add support for regexps from JSON .eslintrc

### DIFF
--- a/rules/ng_controller_name.js
+++ b/rules/ng_controller_name.js
@@ -8,25 +8,44 @@ module.exports = function(context) {
 
         'CallExpression': function(node) {
 
-            var prefix = context.options[0];
+            var prefix = context.options[0],
+                convertedPrefix = prefix, // convert string from JSON .eslintrc to regex
+
+                // is supplied prefix a string containing a regex?
+                // used to provide correct error message
+                prefixIsRegex = false;
 
             if(prefix === undefined) {
                 return;
             }
 
-            if (utils.isAngularControllerDeclaration(node)) {
+            if(typeof prefix === 'string') {
+                // remove starting and ending slashes because new RegExp() adds them
+                if(convertedPrefix[0] === '/' && convertedPrefix[convertedPrefix.length - 1]) {
+                    convertedPrefix = convertedPrefix.substring(1, convertedPrefix.length - 1);
+                    prefixIsRegex = true;
+                }
+                // add .* so normal strings for matching the start of a controller name still pass
+                convertedPrefix = new RegExp(convertedPrefix + ".*");
+            }
+
+
+            var callee = node.callee;
+            if(callee.type === 'MemberExpression' && callee.property.name === 'controller') {
                 var name = node.arguments[0].value;
 
-               if(name !== undefined && !utils.isRegexp(prefix) && !(name.indexOf(prefix) === 0)){
-                    context.report(node, 'The {{controller}} controller should be prefixed by {{prefix}}', {
-                        controller: name,
-                        prefix: prefix
-                    });
-                } else if(utils.isRegexp(prefix) && !prefix.test(name)){
-                    context.report(node, 'The {{controller}} controller should follow this pattern: {{prefix}}', {
-                        controller: name,
-                        prefix: prefix.toString()
-                   });
+               if(name !== undefined && !convertedPrefix.test(name)){
+                    if(typeof prefix === 'string' && !prefixIsRegex) {
+                        context.report(node, 'The {{controller}} controller should be prefixed by {{prefix}}', {
+                            controller: name,
+                            prefix: prefix
+                        });
+                    } else {
+                        context.report(node, 'The {{controller}} controller should follow this pattern: {{prefix}}', {
+                            controller: name,
+                            prefix: prefix.toString()
+                       });
+                    }
                 }
 
             }

--- a/rules/ng_controller_name.js
+++ b/rules/ng_controller_name.js
@@ -2,8 +2,6 @@ module.exports = function(context) {
 
     'use strict';
 
-    var utils = require('./utils/utils');
-
     return {
 
         'CallExpression': function(node) {
@@ -26,7 +24,7 @@ module.exports = function(context) {
                     prefixIsRegex = true;
                 }
                 // add .* so normal strings for matching the start of a controller name still pass
-                convertedPrefix = new RegExp(convertedPrefix + ".*");
+                convertedPrefix = new RegExp(convertedPrefix + '.*');
             }
 
 

--- a/test/ng_controller_name.js
+++ b/test/ng_controller_name.js
@@ -23,6 +23,9 @@ eslintTester.addRuleTest('rules/ng_controller_name', {
     }, {
         code: 'app.controller("EslintController", function(){});',
         args: [1, /[A-Z].*Controller$/]
+    }, {
+        code: 'app.controller("EslintController", function(){});',
+        args: [1, "/[A-Z].*Controller$/"]
     }],
     invalid: [
         {
@@ -49,6 +52,10 @@ eslintTester.addRuleTest('rules/ng_controller_name', {
             code: 'app.controller("customersController", function(){});',
             args: [1, /[A-Z].*Controller$/],
             errors: [{ message: 'The customersController controller should follow this pattern: /[A-Z].*Controller$/'}]
+        }, {
+            code: 'app.controller("eslintController", function(){});',
+            args: [1, "/[A-Z].*Controller$/"],
+            errors: [{ message: 'The eslintController controller should follow this pattern: /[A-Z].*Controller$/'}]
         }
     ]
 });


### PR DESCRIPTION
I haven't found a way to use RegExps in JSON formatted .eslintrc, but this adds support for them. Should fix #68. 