### PR TITLE
Fix grunt version of demo

### DIFF
--- a/demo/grunt/package.json
+++ b/demo/grunt/package.json
@@ -10,8 +10,8 @@
   "license": "MIT",
   "devDependencies": {
     "eslint": "^0.16.1",
-    "eslint-plugin-angular": "0.0.6",
-    "grunt-cli": "^0.1.13",
+    "eslint-plugin-angular": "file:../../",
+    "grunt": "^0.4.5",
     "grunt-eslint": "^7.0.1"
   }
 }


### PR DESCRIPTION
I was trying to run the grunt version of the demo and was getting "Fatal error: Unable to find local grunt." when running grunt from the terminal. I noticed it was including the grunt-cli package instead of grunt itself. So, I updated that and set the eslint-plugin-angular version to match the other demos.

Nice job on the plugin, I'm hoping to get my company using it for our Angular apps.