### PR TITLE
make angular object list configurable for ng_no_services

### DIFF
--- a/rules/ng_no_services.js
+++ b/rules/ng_no_services.js
@@ -6,26 +6,66 @@ module.exports = function(context) {
 
     var angularObjectList = ['controller', 'filter', 'directive'];
     var message = 'REST API calls should be implemented in a specific service';
+
+    function isArray(item) {
+        return Object.prototype.toString.call(item) === '[object Array]';
+    }
+
+    function isObject(item) {
+        return Object.prototype.toString.call(item) === '[object Object]';
+    }
+
+    if (isArray(context.options[0])) {
+        var badServices = context.options[0];
+    }
+
+    if (isArray(context.options[1])) {
+        angularObjectList = context.options[1];
+    }
+
+    if (isObject(context.options[0])) {
+        var map = context.options[0],
+            result = [],
+            prop;
+
+        for (prop in map) {
+            if (map.hasOwnProperty(prop)) {
+                result.push(prop);
+            }
+        }
+
+        angularObjectList = result;
+    }
+
+    function isSetBedService(serviceName, angularObjectName) {
+        if (map) {
+            return map[angularObjectName].indexOf(serviceName) >= 0;
+        }
+        else {
+            return badServices.indexOf(serviceName) >= 0;
+        }
+    }
+
     return {
 
         'CallExpression': function(node) {
 
-            var badServices = context.options[0];
-            var callee = node.callee;
+            var callee = node.callee,
+                angularObjectName = callee.property.name;
 
-            if (utils.isAngularComponent(node) && callee.type === 'MemberExpression' && angularObjectList.indexOf(callee.property.name) >= 0) {
+            if (utils.isAngularComponent(node) && callee.type === 'MemberExpression' && angularObjectList.indexOf(angularObjectName) >= 0) {
                if(utils.isFunctionType(node.arguments[1])){
                    node.arguments[1].params.forEach(function(service){
-                    if(service.type === 'Identifier' && badServices.indexOf(service.name) >= 0){
-                      context.report(node, message, {});
+                    if(service.type === 'Identifier' && isSetBedService(service.name, angularObjectName)){
+                      context.report(node, message + ' (' + service.name + ' in ' + angularObjectName + ')', {});
                     }
                   });
                }
 
               if(utils.isArrayType(node.arguments[1])){
                 node.arguments[1].elements.forEach(function(service){
-                  if(service.type === 'Literal' && badServices.indexOf(service.value) >= 0){
-                    context.report(node, message, {});
+                  if(service.type === 'Literal' && isSetBedService(service.value, angularObjectName)){
+                    context.report(node, message + ' (' + service.value + ' in ' + angularObjectName + ')', {});
                   }
                 });
               }

--- a/test/ng_no_services.js
+++ b/test/ng_no_services.js
@@ -7,6 +7,11 @@ var eslint = require('../node_modules/eslint/lib/eslint'),
 
 var angularObjectList = ['controller', 'filter', 'directive'];
 var defaultBadService = ['$http', '$resource', 'Restangular', '$q'];
+var mapAngularObjectToBarServices = {
+    controller: defaultBadService,
+    filter: defaultBadService,
+    directive: defaultBadService
+};
 var valid = [], invalid = [];
 
 angularObjectList.forEach(function(object){
@@ -22,15 +27,62 @@ angularObjectList.forEach(function(object){
         invalid.push({
             code: 'app.' + object + '("name", function(' + badService + '){});',
             args: [1, defaultBadService],
-            errors: [{ message: 'REST API calls should be implemented in a specific service'}]
+            errors: [{ message: 'REST API calls should be implemented in a specific service (' + badService + ' in ' + object + ')'}]
         }, {
             code: 'app.' + object + '("name", ["' + badService + '", function(' + badService + '){}]);',
             args: [1, defaultBadService],
-            errors: [{ message: 'REST API calls should be implemented in a specific service'}]
+            errors: [{ message: 'REST API calls should be implemented in a specific service (' + badService + ' in ' + object + ')'}]
         });
     });
 
 });
+
+angularObjectList.forEach(function(object){
+    valid.push({
+        code: 'app.' + object + '("name", function(Service1){});',
+        args: [1, defaultBadService, [object]]
+    }, {
+        code: 'app.' + object + '("name", ["Service1", function(Service1){}]);',
+        args: [1, defaultBadService, [object]]
+    });
+
+    defaultBadService.forEach(function(badService){
+        invalid.push({
+            code: 'app.' + object + '("name", function(' + badService + '){});',
+            args: [1, defaultBadService, [object]],
+            errors: [{ message: 'REST API calls should be implemented in a specific service (' + badService + ' in ' + object + ')'}]
+        }, {
+            code: 'app.' + object + '("name", ["' + badService + '", function(' + badService + '){}]);',
+            args: [1, defaultBadService, [object]],
+            errors: [{ message: 'REST API calls should be implemented in a specific service (' + badService + ' in ' + object + ')'}]
+        });
+    });
+
+});
+
+angularObjectList.forEach(function(object){
+    valid.push({
+        code: 'app.' + object + '("name", function(Service1){});',
+        args: [1, mapAngularObjectToBarServices]
+    }, {
+        code: 'app.' + object + '("name", ["Service1", function(Service1){}]);',
+        args: [1, mapAngularObjectToBarServices]
+    });
+
+    defaultBadService.forEach(function(badService){
+        invalid.push({
+            code: 'app.' + object + '("name", function(' + badService + '){});',
+            args: [1, mapAngularObjectToBarServices],
+            errors: [{ message: 'REST API calls should be implemented in a specific service (' + badService + ' in ' + object + ')'}]
+        }, {
+            code: 'app.' + object + '("name", ["' + badService + '", function(' + badService + '){}]);',
+            args: [1, mapAngularObjectToBarServices],
+            errors: [{ message: 'REST API calls should be implemented in a specific service (' + badService + ' in ' + object + ')'}]
+        });
+    });
+
+});
+
 //------------------------------------------------------------------------------
 // Tests
 //------------------------------------------------------------------------------


### PR DESCRIPTION
This PR provides three way of configuration and resolves #88:
1\. just a list of services (as it was)
```
'ng_no_services': [2, ['$http', '$resource', 'Restangular']]
```
2\. a list of services and a list of angular objects
```
'ng_no_services': [2, ['$http', '$resource', 'Restangular'], ['controller', 'factory']]
```
3\. angular objects and services for each of them
```
'ng_no_services': [2, {controller: ['$http', '$q'], factory: ['Restangular']}]
```