### PR TITLE
Be more lenient with $destroy in ng_on_watch.

### DIFF
--- a/test/ng_on_watch.js
+++ b/test/ng_on_watch.js
@@ -17,7 +17,13 @@ eslintTester.addRuleTest('rules/ng_on_watch', {
         'var variable = $scope.$on()',
         'var variable = $scope.$watch()',
         'var variable = $rootScope.$on()',
-        'var variable = $rootScope.$watch()'
+        'var variable = $rootScope.$watch()',
+        '$scope.$on("$destroy")',
+        '$rootScope.$on("$destroy")',
+        '$scope.$on("$destroy", $scope.$on())',
+        '$rootScope.$on("$destroy", $scope.$on())',
+        '$scope.$on("$destroy", $rootScope.$on())',
+        '$rootScope.$on("$destroy", $rootScope.$on())'
     ],
     invalid: [
         { code: 'scope.$on()', errors: [{ message: 'The "$on" call should be assigned to a variable, in order to be destroyed during the $destroy event'}] },


### PR DESCRIPTION
Do not require capturing of $destroy handlers.
Allow $on handlers to be captured directly in $destroy handlers in
addition to assigning to variables.

Fixes #107