### PR TITLE
Add rule for enforcing directive restrictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Users may use the shareable [eslint-config-angular](https://github.com/dustinspe
         "angular/di": [2, "function"],
         "angular/di-order": [0, true],
         "angular/directive-name": 0,
+        "angular/directive-restrict": [0, {"restrict": "AE", "explicit": "never"}],
         "angular/component-limit": [0, 1],
         "angular/document-service": 2,
         "angular/empty-controller": 0,
@@ -171,6 +172,7 @@ Users may use the shareable [eslint-config-angular](https://github.com/dustinspe
 | di                        | All your DI should use the same syntax : the Array or function syntaxes ("di":  [2, "function or array"])|
 | di-order                  | Injected dependencies should be sorted alphabetically. If the second parameter is set to false, values which start and end with an underscore those underscores are stripped. This means for example that `_$httpBackend_` goes before `_$http_`. |
 | directive-name            | All your directives should have a name starting with the parameter you can define in your config object. The second parameter can be a Regexp wrapped in quotes. You can not prefix your directives by "ng" (reserved keyword for AngularJS directives) ("directive-name":  [2, "ng"]) [Y073](https://github.com/johnpapa/angular-styleguide#style-y073), [Y126](https://github.com/johnpapa/angular-styleguide#style-y126) |
+| directive-restrict        | Not all directive restrictions may be desirable. Also it might be desirable to define default restrictions, or explicitly not. The default configuration limits the restrictions `AE` [Y074](https://github.com/johnpapa/angular-styleguide#style-y074) and disallows explicitly specifying a default. ("directive-restrict": [0, {"restrict": "AE", "explicit": "never"}]) |
 | document-service          | Instead of the default document object, you should prefer the AngularJS wrapper service $document. [Y180](https://github.com/johnpapa/angular-styleguide#style-y180) |
 | empty-controller          | If you have one empty controller, maybe you have linked it in your Router configuration or in one of your views. You can remove this declaration because this controller is useless |
 | file-name                 | All your file names should match the angular component name. The second parameter can be a config object [2, {nameStyle: 'dash', typeSeparator: 'dot', ignoreTypeSuffix: true, ignorePrefix: 'ui'}] to match 'avenger-profile.directive.js' or 'avanger-api.service.js'. Possible values for 'typeSeparator' and 'nameStyle' are 'dot', 'dash' and 'underscore'. The options 'ignoreTypeSuffix' ignores camel cased suffixes like 'someController' or 'myService' and 'ignorePrefix' ignores namespace prefixes like 'ui'. [Y120](https://github.com/johnpapa/angular-styleguide#style-y120) [Y121](https://github.com/johnpapa/angular-styleguide#style-y121) |

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ rulesConfiguration.addRule('di', [2, 'function']);
 rulesConfiguration.addRule('di-order', 0);
 rulesConfiguration.addRule('di-unused', 0);
 rulesConfiguration.addRule('directive-name', 0);
+rulesConfiguration.addRule('directive-restrict', 0);
 rulesConfiguration.addRule('document-service', 2);
 rulesConfiguration.addRule('empty-controller', 0);
 rulesConfiguration.addRule('foreach', 0);

--- a/rules/directive-restrict.js
+++ b/rules/directive-restrict.js
@@ -1,0 +1,97 @@
+'use strict';
+
+module.exports = function(context) {
+    var utils = require('./utils/utils');
+
+    var options = context.options[0] || {};
+    var restrictOpt = options.restrict || 'AE';
+    var explicitRestrict = options.explicit === 'always';
+    var restrictChars = [];
+
+    restrictOpt.split('').forEach(function(char) {
+        if ('ACEM'.indexOf(char) === -1) {
+            return;
+        }
+        restrictChars.push(char);
+    });
+
+    restrictOpt = restrictChars.join('');
+    // Example RegExp for ACEM: /^A?C?E?M?$/
+    var restrictRegExp = new RegExp('^' + restrictChars.join('?') + '?$');
+    var uncheckedDirectives = [];
+    var defaultRestrictions = ['AE', 'EA'];
+
+    function checkLiteralNode(node) {
+        if (node.type !== 'Literal') {
+            return;
+        }
+        var directiveNode;
+        context.getAncestors().some(function(ancestor) {
+            if (utils.isAngularDirectiveDeclaration(ancestor)) {
+                directiveNode = ancestor;
+                return true;
+            }
+        });
+        // The restrict property was not defined inside of a directive.
+        if (!directiveNode) {
+            return;
+        }
+        if (!explicitRestrict && defaultRestrictions.indexOf(node.value) !== -1) {
+            context.report(node, 'No need to explicitly specify a default directive restriction');
+            return;
+        }
+        if (restrictRegExp.test(node.value)) {
+            uncheckedDirectives.splice(uncheckedDirectives.indexOf(directiveNode), 1);
+            return;
+        }
+        context.report(directiveNode, 'Disallowed directive restriction. It must be one of {{allowed}} in that order', {
+            allowed: restrictOpt
+        });
+    }
+
+    return {
+        CallExpression: function(node) {
+            if (utils.isAngularDirectiveDeclaration(node)) {
+                uncheckedDirectives.push(node);
+            }
+        },
+        AssignmentExpression: function(node) {
+            // Only check for literal member property assignments.
+            if (node.left.type !== 'MemberExpression') {
+                return;
+            }
+            // Only check setting properties named 'restrict'.
+            if (node.left.property.name !== 'restrict') {
+                return;
+            }
+            checkLiteralNode(node.right);
+        },
+        Property: function(node) {
+            // This only checks for objects which have defined a literal restrict property.
+            if (node.key.name !== 'restrict') {
+                return;
+            }
+            checkLiteralNode(node.value);
+        },
+        'Program:exit': function() {
+            if (explicitRestrict) {
+                uncheckedDirectives.forEach(function(directiveNode) {
+                    context.report(directiveNode, 'Missing directive restriction');
+                });
+            }
+        }
+    };
+};
+
+module.exports.schema = [{
+    type: 'object',
+    properties: {
+        restrict: {
+            type: 'string',
+            pattern: '^[ACEM]{1,4}$'
+        },
+        explicit: {
+            enum: ['always', 'never']
+        }
+    }
+}];

--- a/rules/directive-restrict.js
+++ b/rules/directive-restrict.js
@@ -8,7 +8,7 @@ module.exports = function(context) {
     var explicitRestrict = options.explicit === 'always';
     var restrictChars = restrictOpt.split('');
 
-    // Example RegExp for ACEM: /^A?C?E?M?$/
+    // Example RegExp for AE: /^A?E?$/
     var restrictRegExp = new RegExp('^' + restrictChars.join('?') + '?$');
     var foundDirectives = [];
     var checkedDirectives = [];

--- a/test/directive-restrict.js
+++ b/test/directive-restrict.js
@@ -1,0 +1,90 @@
+'use strict';
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+var rule = require('../rules/directive-restrict');
+var RuleTester = require('eslint').RuleTester;
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+var eslintTester = new RuleTester();
+eslintTester.run('directive-restrict', rule, {
+    valid: [
+        // Non directive components
+        'app.factory("", function() {return {restrict:"ACEM"}})',
+        'app.directive("")',
+        'app.directive()',
+        // Allowed with default configuration
+        'app.directive("", function() {})',
+        'app.directive("", function() {return {anotherProperty:"anotherValue"}})',
+        'app.directive("", function() {return {restrict:"A"}})',
+        'app.directive("", function() {return {restrict:"E"}})',
+        // Allowed with custom restrict
+        {
+            code: 'app.directive("", function() {return {restrict:"M"}})',
+            options: [{restrict: 'AEM'}]
+        }, {
+            code: 'app.directive("", function() {return {restrict:"CM"}})',
+            options: [{restrict: 'CM'}]
+        },
+        // Allowed with explicit restrict
+        {
+            code: 'app.directive("", function() {return {restrict:"AE"}})',
+            options: [{explicit: 'always'}]
+        }, {
+            code: 'app.directive("", function() {return {restrict:"EA"}})',
+            options: [{restrict: 'EA', explicit: 'always'}]
+        }, {
+            code: 'app.directive("", function() {directive = {restrict:"A"}; return directive})',
+            options: [{explicit: 'always'}]
+        }, {
+            code: 'app.directive("", function() {directive = {}; directive.restrict = "A"; return directive})',
+            options: [{explicit: 'always'}]
+        }, {
+            code: 'app.directive("", function() {directive = {}; directive.restrict = restrict; return directive})'
+        }, {
+            code: 'app.directive("", function() {directive = {}; directive.custom = "A"; return directive})'
+        }
+    ],
+    invalid: [
+        // Disallowed with default configuration
+        {
+            code: 'app.directive("", function() {return {restrict:"C"}})',
+            errors: [{message: 'Disallowed directive restriction. It must be one of AE in that order'}]
+        }, {
+            code: 'app.directive("", function() {return {restrict:"M"}})',
+            errors: [{message: 'Disallowed directive restriction. It must be one of AE in that order'}]
+        }, {
+            code: 'app.directive("", function() {var directive = {restrict:"M"};return directive;})',
+            errors: [{message: 'Disallowed directive restriction. It must be one of AE in that order'}]
+        },
+        // Disallowed with custom restrict
+        {
+            code: 'app.directive("", function() {return {restrict:"M"}})',
+            options: [{restrict: 'ACE'}],
+            errors: [{message: 'Disallowed directive restriction. It must be one of ACE in that order'}]
+        }, {
+            code: 'app.directive("", function() {return {restrict:"AC"}})',
+            options: [{restrict: 'CM'}],
+            errors: [{message: 'Disallowed directive restriction. It must be one of CM in that order'}]
+        },
+        // Disallowed with explicit restrict
+        {
+            code: 'app.directive("", function() {return {restrict:"EA"}})',
+            errors: [{message: 'No need to explicitly specify a default directive restriction'}]
+        }, {
+            code: 'app.directive("", function() {return {restrict:"AE"}})',
+            errors: [{message: 'No need to explicitly specify a default directive restriction'}]
+        },
+        // Missing restrict with explicit set to always
+        {
+            code: 'app.directive("", function() {})',
+            errors: [{message: 'Missing directive restriction'}],
+            options: [{explicit: 'always'}]
+        }
+    ]
+});


### PR DESCRIPTION
There are some corner cases. For example when setting a property named `restrict` to another object inside of a directive declaration. I think this is rare though.

Closes #23 