### PR TITLE
Add rule disallowing inline templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Users may use the shareable [eslint-config-angular](https://github.com/dustinspe
 | no-controller             | According to the Component-First pattern, we should avoid the use of AngularJS controller. |
 | no-cookiestore            | In Angular 1.4, the $cookieStore service is now deprected. Please use the $cookies service instead|
 | no-digest                 | DEPRECATED! The scope's $digest() method shouldn't be used. You should prefer the $apply method. |
-| no-inline-template        | Instead of using inline HTML templates, it is better to load the HTML from an external file. Simple HTML templates are accepted by default. ('allow-complex': [0, {allowSimple: true}]) |
+| no-inline-template        | Instead of using inline HTML templates, it is better to load the HTML from an external file. Simple HTML templates are accepted by default. ('no-inline-template': [0, {allowSimple: true}]) |
 | no-jquery-angularelement  | You should not wrap angular.element object into jQuery(), because angular.element already return jQLite element|
 | no-private-call           | All scope's properties/methods starting with $$ are used internally by AngularJS. You should not use them directly. Exception can be allowed with this option: {allow:['$$watchers']} |
 | no-service-method         | You should prefer the factory() method instead of service() [Y040](https://github.com/johnpapa/angular-styleguide#style-y040)|

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Users may use the shareable [eslint-config-angular](https://github.com/dustinspe
         "angular/no-controller": 0,
         "angular/no-cookiestore": 2,
         "angular/no-digest": 2,
+        "angular/no-inline-template": [0, {"allowSimple": true}],
         "angular/no-jquery-angularelement": 2,
         "angular/no-private-call": 2,
         "angular/no-service-method": 2,
@@ -187,6 +188,7 @@ Users may use the shareable [eslint-config-angular](https://github.com/dustinspe
 | no-controller             | According to the Component-First pattern, we should avoid the use of AngularJS controller. |
 | no-cookiestore            | In Angular 1.4, the $cookieStore service is now deprected. Please use the $cookies service instead|
 | no-digest                 | DEPRECATED! The scope's $digest() method shouldn't be used. You should prefer the $apply method. |
+| no-inline-template        | Instead of using inline HTML templates, it is better to load the HTML from an external file. Simple HTML templates are accepted by default. ('allow-complex': [0, {allowSimple: true}]) |
 | no-jquery-angularelement  | You should not wrap angular.element object into jQuery(), because angular.element already return jQLite element|
 | no-private-call           | All scope's properties/methods starting with $$ are used internally by AngularJS. You should not use them directly. Exception can be allowed with this option: {allow:['$$watchers']} |
 | no-service-method         | You should prefer the factory() method instead of service() [Y040](https://github.com/johnpapa/angular-styleguide#style-y040)|

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ rulesConfiguration.addRule('no-angular-mock', 0);
 rulesConfiguration.addRule('no-controller', 0);
 rulesConfiguration.addRule('no-cookiestore', 2);
 rulesConfiguration.addRule('no-digest', 0);
+rulesConfiguration.addRule('no-inline-template', [0, {'allow-simple': true}]);
 rulesConfiguration.addRule('no-jquery-angularelement', 2);
 rulesConfiguration.addRule('no-private-call', 2);
 rulesConfiguration.addRule('no-services', [2, ['$http', '$resource', 'Restangular', '$q']]);

--- a/rules/no-inline-template.js
+++ b/rules/no-inline-template.js
@@ -1,0 +1,40 @@
+'use strict';
+
+module.exports = function(context) {
+    // Extracts any HTML tags.
+    var regularTagPattern = /<(.+?)>/g;
+    // Extracts self closing HTML tags.
+    var selfClosingTagPattern = /<(.+?)\/>/g;
+
+    var allowSimple = (context.options[0] && context.options[0].allowSimple) !== false;
+
+    function reportComplex(node) {
+        context.report(node, 'Inline template is too complex. Use an external template instead');
+    }
+
+    return {
+        Property: function(node) {
+            if (node.key.name !== 'template' || node.value.type !== 'Literal') {
+                return;
+            }
+            if (!allowSimple) {
+                context.report(node, 'Inline templates are not allowed. Use an external template instead');
+            }
+            if ((node.value.value.match(regularTagPattern) || []).length > 2) {
+                return reportComplex(node);
+            }
+            if ((node.value.value.match(selfClosingTagPattern) || []).length > 1) {
+                return reportComplex(node);
+            }
+            if (node.value.raw.indexOf('\\') !== -1) {
+                reportComplex(node);
+            }
+        }
+    };
+};
+
+module.exports.schema = [{
+    allowSimple: {
+        type: 'boolean'
+    }
+}];

--- a/test/no-inline-template.js
+++ b/test/no-inline-template.js
@@ -1,0 +1,43 @@
+'use strict';
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+var rule = require('../rules/no-inline-template');
+var RuleTester = require('eslint').RuleTester;
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+var eslintTester = new RuleTester();
+eslintTester.run('no-inline-template', rule, {
+    valid: [
+        'function foo() {return {template:"<div></div>"};}',
+        'function foo() {return {template:getTemplate()};}',
+        'function foo() {return {bar:"baz"};}',
+        'function foo() {return {template:"<img/>"};}'
+    ],
+    invalid: [
+        {
+            code: 'function foo() {return {template:"<div><div></div></div>"};}',
+            errors: [{message: 'Inline template is too complex. Use an external template instead'}]
+        }, {
+            code: 'function foo() {return {template:"<img/><img/>"};}',
+            errors: [{message: 'Inline template is too complex. Use an external template instead'}]
+        }, {
+            code: 'function foo() {return {template:"<div ng-class=\'{\\\'error\\\':vm.error}\'></div>"};}',
+            errors: [{message: 'Inline template is too complex. Use an external template instead'}]
+        }, {
+            code: 'function foo() {return {template:"<img ng-src=\\"\\\'logo.png\\\'\\"/>"};}',
+            errors: [{message: 'Inline template is too complex. Use an external template instead'}]
+        },
+        // disallow simple
+        {
+            code: 'function foo() {return {template:""};}',
+            options: [{allowSimple: false}],
+            errors: [{message: 'Inline templates are not allowed. Use an external template instead'}]
+        }
+    ]
+});


### PR DESCRIPTION
Templates are considered too complex if they consist of more than one html template or escape a character using a backslash.

Closes #58 