### PR TITLE
Increase coverage

### DIFF
--- a/rules/on-watch.js
+++ b/rules/on-watch.js
@@ -46,10 +46,6 @@ module.exports = function(context) {
      * argument of the string '$destroy'.
      */
     function isFirstArgDestroy(node) {
-        if (node.type !== 'CallExpression') {
-            return false;
-        }
-
         var args = node.arguments;
 
         return (args.length >= 1 &&

--- a/test/on-watch.js
+++ b/test/on-watch.js
@@ -30,7 +30,13 @@ eslintTester.run('on-watch', rule, {
         'scope.$on()',
         'scope.$watch()',
         '$scope.$on()',
-        '$scope.$watch()'
+        '$scope.$watch()',
+
+        // false positive check
+        '$on()',
+
+        // uncovered edgecase
+        '$scope["$on"]()'
 
     ],
     invalid: [


### PR DESCRIPTION
Changes to increase the statement coverage to 100%.

The problem with the current almost 100% coverage is that removing lines in other parts of the source lead to a relative coverage decrease. 805/808 is a higher coverage than 800/803.

https://coveralls.io/builds/3828298