### PR TITLE
Angular rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -158,7 +158,7 @@ rules:
   indent:
     - 2
     - 4
-    - SwitchCase: 4
+    - SwitchCase: 1
   key-spacing:
     - 2
     - beforeColon: false

--- a/docs/component-limit.md
+++ b/docs/component-limit.md
@@ -16,7 +16,7 @@ The following patterns are considered problems with default config;
     /*eslint angular/component-limit: 2*/
 
     // invalid
-    app.controller('ControllerOne', function() {
+    angular.module('myModule').controller('ControllerOne', function() {
         // ...
     }).directive('directiveTwo', function() {
         // ...
@@ -27,7 +27,7 @@ The following patterns are **not** considered problems with default config;
     /*eslint angular/component-limit: 2*/
 
     // valid
-    app.controller('SomeController', function() {
+    angular.module('myModule').controller('SomeController', function() {
         // ...
     });
 
@@ -41,7 +41,7 @@ The following patterns are considered problems when configured `3`:
     /*eslint angular/component-limit: [2,3]*/
 
     // invalid
-    app.controller('ControllerOne', function() {
+    angular.module('myModule').controller('ControllerOne', function() {
         // ...
     }).directive('directiveTwo', function() {
         // ...
@@ -56,7 +56,7 @@ The following patterns are **not** considered problems when configured `3`:
     /*eslint angular/component-limit: [2,3]*/
 
     // valid
-    app.controller('ControllerOne', function() {
+    angular.module('myModule').controller('ControllerOne', function() {
         // ...
     }).directive('directiveTwo', function() {
         // ...

--- a/examples/component-limit.js
+++ b/examples/component-limit.js
@@ -1,5 +1,5 @@
 // example - valid: true
-app.controller('SomeController', function() {
+angular.module('myModule').controller('SomeController', function() {
     // ...
 });
 
@@ -9,14 +9,14 @@ angular.module('myModule').directive('myDirective', function() {
 });
 
 // example - valid: false, errorMessage: "There may be at most 1 AngularJS component per file, but found 2"
-app.controller('ControllerOne', function() {
+angular.module('myModule').controller('ControllerOne', function() {
     // ...
 }).directive('directiveTwo', function() {
     // ...
 });
 
 // example - valid: true, options: [3]
-app.controller('ControllerOne', function() {
+angular.module('myModule').controller('ControllerOne', function() {
     // ...
 }).directive('directiveTwo', function() {
     // ...
@@ -25,7 +25,7 @@ app.controller('ControllerOne', function() {
 });
 
 // example - valid: false, options: [3], errorMessage: "There may be at most 3 AngularJS components per file, but found 4"
-app.controller('ControllerOne', function() {
+angular.module('myModule').controller('ControllerOne', function() {
     // ...
 }).directive('directiveTwo', function() {
     // ...

--- a/rules/component-limit.js
+++ b/rules/component-limit.js
@@ -9,33 +9,36 @@
  */
 'use strict';
 
-module.exports = function(context) {
-    var utils = require('./utils/utils');
-    var limit = context.options[0] || 1;
+var angularRule = require('./utils/angular-rule');
 
-    var components = [];
+
+module.exports = angularRule(function(context) {
+    var limit = context.options[0] || 1;
+    var count = 0;
     var msg = 'There may be at most {{limit}} AngularJS {{component}} per file, but found {{number}}';
 
-    return {
-        CallExpression: function(node) {
-            if (utils.isAngularComponent(node) && utils.isMemberExpression(node.callee)) {
-                components.push(node);
-            }
-        },
-
-        'Program:exit': function() {
-            if (components.length > limit) {
-                components.slice(limit).forEach(function(node) {
-                    context.report(node, msg, {
-                        limit: limit,
-                        component: limit === 1 ? 'component' : 'components',
-                        number: components.length
-                    });
-                });
-            }
+    function checkLimit(callee) {
+        count++;
+        if (count > limit) {
+            context.report(callee, msg, {
+                limit: limit,
+                component: limit === 1 ? 'component' : 'components',
+                number: count
+            });
         }
+    }
+
+    return {
+        'angular:config': checkLimit,
+        'angular:controller': checkLimit,
+        'angular:directive': checkLimit,
+        'angular:factory': checkLimit,
+        'angular:filter': checkLimit,
+        'angular:provider': checkLimit,
+        'angular:run': checkLimit,
+        'angular:service': checkLimit
     };
-};
+});
 
 module.exports.schema = [{
     type: 'integer'

--- a/rules/component-limit.js
+++ b/rules/component-limit.js
@@ -29,6 +29,7 @@ module.exports = angularRule(function(context) {
     }
 
     return {
+        'angular:animation': checkLimit,
         'angular:config': checkLimit,
         'angular:controller': checkLimit,
         'angular:directive': checkLimit,

--- a/rules/di-order.js
+++ b/rules/di-order.js
@@ -35,6 +35,7 @@ module.exports = angularRule(function(context) {
     }
 
     return {
+        'angular:animation': checkOrder,
         'angular:config': checkOrder,
         'angular:controller': checkOrder,
         'angular:directive': checkOrder,

--- a/rules/di-order.js
+++ b/rules/di-order.js
@@ -9,28 +9,18 @@
  */
 'use strict';
 
-module.exports = function(context) {
-    var utils = require('./utils/utils');
+var angularRule = require('./utils/angular-rule');
 
-    var angularNamedObjectList = [
-        'controller',
-        'directive',
-        'factory',
-        'filter',
-        'provider',
-        'service'
-    ];
-    var setupCalls = [
-        'config',
-        'run'
-    ];
 
-    function checkOrder(fn) {
+module.exports = angularRule(function(context) {
+    var stripUnderscores = context.options[0] !== false;
+
+    function checkOrder(callee, fn) {
         if (!fn || !fn.params) {
             return;
         }
         var args = fn.params.map(function(arg) {
-            if (context.options[0] !== false) {
+            if (stripUnderscores) {
                 return arg.name.replace(/^_(.+)_$/, '$1');
             }
             return arg.name;
@@ -45,27 +35,17 @@ module.exports = function(context) {
     }
 
     return {
-
-        AssignmentExpression: function(node) {
-            // The $get function of a provider.
-            if (node.left.type === 'MemberExpression' && node.left.property.name === '$get') {
-                return checkOrder(node.right);
-            }
-        },
-
-        CallExpression: function(node) {
-            // An Angular component definition.
-            if (utils.isAngularComponent(node) && node.callee.type === 'MemberExpression' && node.arguments[1].type === 'FunctionExpression' && angularNamedObjectList.indexOf(node.callee.property.name) >= 0) {
-                return checkOrder(node.arguments[1]);
-            }
-            // Config and run functions.
-            if (node.callee.type === 'MemberExpression' && node.arguments.length > 0 && setupCalls.indexOf(node.callee.property.name) !== -1 && node.arguments[0].type === 'FunctionExpression') {
-                return checkOrder(node.arguments[0]);
-            }
-            // Injected values in unittests.
-            if (node.callee.type === 'Identifier' && node.callee.name === 'inject') {
-                return checkOrder(node.arguments[0]);
-            }
+        'angular:config': checkOrder,
+        'angular:controller': checkOrder,
+        'angular:directive': checkOrder,
+        'angular:factory': checkOrder,
+        'angular:filter': checkOrder,
+        'angular:inject': checkOrder,
+        'angular:run': checkOrder,
+        'angular:service': checkOrder,
+        'angular:provider': function(callee, providerFn, $get) {
+            checkOrder(null, providerFn);
+            checkOrder(null, $get);
         }
     };
-};
+});

--- a/rules/di-unused.js
+++ b/rules/di-unused.js
@@ -48,6 +48,7 @@ module.exports = angularRule(function(context) {
     }
 
     return {
+        'angular:animation': reportUnusedVariables,
         'angular:config': reportUnusedVariables,
         'angular:controller': reportUnusedVariables,
         'angular:directive': reportUnusedVariables,

--- a/rules/di-unused.js
+++ b/rules/di-unused.js
@@ -7,24 +7,10 @@
  */
 'use strict';
 
-module.exports = function(context) {
-    var utils = require('./utils/utils');
+var angularRule = require('./utils/angular-rule');
 
-    var angularNamedObjectList = [
-        'controller',
-        'directive',
-        'factory',
-        'filter',
-        'provider',
-        'service'
-    ];
-    var setupCalls = [
-        'config',
-        'run'
-    ];
 
-    var injectFunctions = [];
-
+module.exports = angularRule(function(context) {
     // Keeps track of visited scopes in the collectAngularScopes function to prevent infinite recursion on circular references.
     var visitedScopes = [];
 
@@ -32,68 +18,53 @@ module.exports = function(context) {
     function collectAngularScopes(scope) {
         if (visitedScopes.indexOf(scope) === -1) {
             visitedScopes.push(scope);
-            injectFunctions.forEach(function(value) {
-                if (scope.block === value.node) {
-                    value.scope = scope;
-                }
-            });
             scope.childScopes.forEach(function(child) {
                 collectAngularScopes(child);
             });
         }
     }
 
+    function reportUnusedVariables(callee, fn) {
+        if (!fn) {
+            return;
+        }
+        visitedScopes.some(function(scope) {
+            if (scope.block !== fn) {
+                return;
+            }
+            scope.variables.forEach(function(variable) {
+                if (variable.name === 'arguments') {
+                    return;
+                }
+                if (fn.params.indexOf(variable.identifiers[0]) === -1) {
+                    return;
+                }
+                if (variable.references.length === 0) {
+                    context.report(fn, 'Unused injected value {{name}}', variable);
+                }
+            });
+            return true;
+        });
+    }
+
     return {
-
-        AssignmentExpression: function(node) {
-            // Colllect the $get function of a providers.
-            if (node.left.type === 'MemberExpression' && node.left.property.name === '$get') {
-                injectFunctions.push({
-                    node: node.right
-                });
-            }
-        },
-
-        CallExpression: function(node) {
-            // An Angular component definition.
-            if (utils.isAngularComponent(node) && node.callee.type === 'MemberExpression' && node.arguments[1].type === 'FunctionExpression' && angularNamedObjectList.indexOf(node.callee.property.name) >= 0) {
-                return injectFunctions.push({
-                    node: node.arguments[1]
-                });
-            }
-            // Config and run functions.
-            if (node.callee.type === 'MemberExpression' && node.arguments.length > 0 && setupCalls.indexOf(node.callee.property.name) !== -1 && node.arguments[0].type === 'FunctionExpression') {
-                return injectFunctions.push({
-                    node: node.arguments[0]
-                });
-            }
-            // Injected values in unittests.
-            if (node.callee.type === 'Identifier' && node.callee.name === 'inject') {
-                return injectFunctions.push({
-                    node: node.arguments[0]
-                });
-            }
+        'angular:config': reportUnusedVariables,
+        'angular:controller': reportUnusedVariables,
+        'angular:directive': reportUnusedVariables,
+        'angular:factory': reportUnusedVariables,
+        'angular:filter': reportUnusedVariables,
+        'angular:inject': reportUnusedVariables,
+        'angular:run': reportUnusedVariables,
+        'angular:service': reportUnusedVariables,
+        'angular:provider': function(callee, providerFn, $get) {
+            reportUnusedVariables(null, providerFn);
+            reportUnusedVariables(null, $get);
         },
 
         // Actually find and report unused injected variables.
         'Program:exit': function() {
             var globalScope = context.getScope();
             collectAngularScopes(globalScope);
-            injectFunctions.forEach(function(value) {
-                if (value.scope) {
-                    value.scope.variables.forEach(function(variable) {
-                        if (variable.name === 'arguments') {
-                            return;
-                        }
-                        if (value.node.params.indexOf(variable.identifiers[0]) === -1) {
-                            return;
-                        }
-                        if (variable.references.length === 0) {
-                            context.report(value.node, 'Unused injected value {{name}}', variable);
-                        }
-                    });
-                }
-            });
         }
     };
-};
+});

--- a/rules/utils/angular-rule.js
+++ b/rules/utils/angular-rule.js
@@ -1,0 +1,221 @@
+'use strict';
+
+module.exports = angularRule;
+
+
+/**
+ * Method names from an AngularJS module which can be chained.
+ */
+var angularChainables = [
+    'config',
+    'constant',
+    'controller',
+    'directive',
+    'factory',
+    'filter',
+    'provider',
+    'run',
+    'service',
+    'value'
+];
+
+
+/**
+ * Angular functions which can be injected.
+ */
+var angularInjectibles = [
+    'config',
+    'controller',
+    'directive',
+    'factory',
+    'filter',
+    'inject',
+    'provider',
+    'run',
+    'service'
+];
+
+
+function angularRule(ruleDefinition) {
+    // This object holds resolved AngularJS module chainables which will be passed to the rule definition.
+    var resolvedChainables;
+    // This object holds AngularJS chainables for which the function reference has not been resolved.
+    var unresolvedChainables;
+    var moduleGetters;
+    var moduleDefinitions;
+
+    return wrapper;
+
+    function reset() {
+        resolvedChainables = {};
+        unresolvedChainables = {};
+        moduleGetters = [];
+        moduleDefinitions = [];
+
+        angularChainables.forEach(function(name) {
+            resolvedChainables[name] = [];
+            unresolvedChainables[name] = [];
+        });
+        resolvedChainables.inject = [];
+        unresolvedChainables.inject = [];
+    }
+
+    /**
+     * A wrapper around the rule definition.
+     */
+    function wrapper(context) {
+        reset();
+        var ruleObject = ruleDefinition(context);
+        // injectCall(ruleObject, context, 'Program', reset);
+        injectCall(ruleObject, context, 'ExpressionStatement', parseAngularComponentChain);
+        injectCall(ruleObject, context, 'AssignmentExpression', collectProviderGet);
+        injectCall(ruleObject, context, 'CallExpression', collectInject);
+        injectCall(ruleObject, context, 'Program:exit', callAngularRules);
+        return ruleObject;
+    }
+
+    /**
+     * Makes sure an extra function gets called after custom defined rule has run.
+     */
+    function injectCall(ruleObject, context, propName, toCallAlso) {
+        var original = ruleObject[propName];
+        ruleObject[propName] = callBoth;
+
+        function callBoth(node) {
+            if (original) {
+                original.call(ruleObject, node);
+            }
+            toCallAlso(ruleObject, context, node);
+        }
+    }
+
+    /**
+     * Collect expressions from an entire Angular module call chain expression statement.
+     *
+     * This collects the following nodes:
+     * ```js
+     * angular.module()
+     *         ^^^^^^
+     * .config(function() {})
+     *  ^^^^^^ ^^^^^^^^^^
+     * .constant()
+     *  ^^^^^^^^
+     * .controller('', function() {})
+     *  ^^^^^^^^^^     ^^^^^^^^^^
+     * .directive('', function() {})
+     *  ^^^^^^^^^     ^^^^^^^^^^
+     * .factory('', function() {})
+     *  ^^^^^^^     ^^^^^^^^^^
+     * .filter('', function() {})
+     *  ^^^^^^     ^^^^^^^^^^
+     * .provider('', function() {})
+     *  ^^^^^^^^     ^^^^^^^^^^
+     * .run('', function() {})
+     *  ^^^     ^^^^^^^^^^
+     * .service('', function() {})
+     *  ^^^^^^^     ^^^^^^^^^^
+     * .value();
+     *  ^^^^^
+     * ```
+     */
+    function parseAngularComponentChain(ruleObject, context, expressionStatementNode) {
+        var collected = [];
+        var module;
+
+        var currentNode = expressionStatementNode.expression;
+        while (currentNode.type === 'CallExpression' && currentNode.callee.type === 'MemberExpression') {
+            if (currentNode.callee.object.name === 'angular' && currentNode.callee.property.name === 'module') {
+                module = currentNode;
+                break;
+            }
+            if (angularChainables.indexOf(currentNode.callee.property.name) === -1) {
+                // This is not a (valid) AngularJS component chain.
+                return;
+            }
+            collected.push(currentNode);
+            currentNode = currentNode.callee.object;
+        }
+        if (!module) {
+            // This is not a valid AngularJS component chain.
+            return;
+        }
+        if (module.arguments.length < 2) {
+            moduleGetters.push(module);
+        } else {
+            moduleDefinitions.push(module);
+        }
+        collected.forEach(function(node) {
+            var name = node.callee.property.name;
+            switch (name) {
+                case 'config':
+                case 'run':
+                    resolvedChainables[name].push({
+                        callee: node,
+                        fn: node.arguments[0]
+                    });
+                    break;
+                case 'controller':
+                case 'directive':
+                case 'factory':
+                case 'filter':
+                case 'provider':
+                case 'service':
+                    resolvedChainables[name].push({
+                        callee: node,
+                        fn: node.arguments[1]
+                    });
+            }
+        });
+    }
+
+    function collectProviderGet(ruleObject, context, assignmentExpressionNode) {
+        if (assignmentExpressionNode.left.type !== 'MemberExpression' || assignmentExpressionNode.left.property.name !== '$get') {
+            return;
+        }
+        var $getScope = context.getScope();
+        resolvedChainables.provider.some(function(provider) {
+            var scope = $getScope;
+            while (scope.upper) {
+                if (scope.block === provider.fn) {
+                    provider.$get = assignmentExpressionNode.right;
+                    return true;
+                }
+                scope = scope.upper;
+            }
+        });
+    }
+
+    /**
+     * Collect calls to spec inject functions.
+     *
+     * This collects the following nodes:
+     * ```js
+     * inject(function() {})
+     * ^^^^^^ ^^^^^^^^^^
+     * ```
+     */
+    function collectInject(ruleObject, context, callExpressionNode) {
+        if (callExpressionNode.callee.type === 'Identifier' && callExpressionNode.callee.name === 'inject') {
+            resolvedChainables.inject.push({
+                node: callExpressionNode,
+                fn: callExpressionNode.arguments[0]
+            });
+        }
+    }
+
+    function callAngularRules(ruleObject) {
+        angularInjectibles.forEach(function(name) {
+            var fn = ruleObject['angular:' + name];
+            if (!fn) {
+                return;
+            }
+            resolvedChainables[name].forEach(function(obj) {
+                var args = [obj.callee, obj.fn];
+                if (name === 'provider') {
+                    args.push(obj.$get);
+                }
+                fn.apply(ruleObject, args);
+            });
+        });
+    }
+}

--- a/rules/utils/angular-rule.js
+++ b/rules/utils/angular-rule.js
@@ -27,15 +27,15 @@ var angularChainableNames = [
  * ```js
  * module.exports = angularRule(function(context) {
  *   return {
- *     'angular.config': function(configCallee, configFn) {},
- *     'angular.controller': function(controllerCallee, controllerFn) {},
- *     'angular.directive': function(directiveCallee, directiveFn) {},
- *     'angular.factory': function(factoryCallee, factoryFn) {},
- *     'angular.filter': function(filterCallee, filterFn) {},
- *     'angular.inject': function(injectCallee, injectFn) {},  // inject() calls from angular-mocks
- *     'angular.run': function(runCallee, runFn) {},
- *     'angular.service': function(serviceCallee, serviceFn) {},
- *     'angular.provider': function(providerCallee, providerFn, provider$getFn) {}
+ *     'angular:config': function(configCallee, configFn) {},
+ *     'angular:controller': function(controllerCallee, controllerFn) {},
+ *     'angular:directive': function(directiveCallee, directiveFn) {},
+ *     'angular:factory': function(factoryCallee, factoryFn) {},
+ *     'angular:filter': function(filterCallee, filterFn) {},
+ *     'angular:inject': function(injectCallee, injectFn) {},  // inject() calls from angular-mocks
+ *     'angular:run': function(runCallee, runFn) {},
+ *     'angular:service': function(serviceCallee, serviceFn) {},
+ *     'angular:provider': function(providerCallee, providerFn, provider$getFn) {}
  *   };
  * })
  * ```

--- a/rules/utils/angular-rule.js
+++ b/rules/utils/angular-rule.js
@@ -7,6 +7,7 @@ module.exports = angularRule;
  * Method names from an AngularJS module which can be chained.
  */
 var angularChainableNames = [
+    'animation',
     'config',
     'constant',
     'controller',
@@ -27,6 +28,7 @@ var angularChainableNames = [
  * ```js
  * module.exports = angularRule(function(context) {
  *   return {
+ *     'angular:animation': function(configCallee, configFn) {},
  *     'angular:config': function(configCallee, configFn) {},
  *     'angular:controller': function(controllerCallee, controllerFn) {},
  *     'angular:directive': function(directiveCallee, directiveFn) {},
@@ -90,6 +92,8 @@ function angularRule(ruleDefinition) {
      * ```js
      * angular.module()
      *         ^^^^^^
+     * .animation('', function() {})
+     *  ^^^^^^^^^     ^^^^^^^^^^
      * .config(function() {})
      *  ^^^^^^ ^^^^^^^^^^
      * .constant()
@@ -229,6 +233,7 @@ function angularRule(ruleDefinition) {
      */
     function assembleArguments(node) {
         switch (node.callExpression.callee.property.name) {
+            case 'animation':
             case 'config':
             case 'controller':
             case 'directive':

--- a/rules/utils/angular-rule.js
+++ b/rules/utils/angular-rule.js
@@ -8,6 +8,7 @@ module.exports = angularRule;
  */
 var angularChainableNames = [
     'animation',
+    'component',
     'config',
     'constant',
     'controller',

--- a/test/component-limit.js
+++ b/test/component-limit.js
@@ -15,37 +15,37 @@ var commonFalsePositives = require('./utils/commonFalsePositives');
 var eslintTester = new RuleTester();
 eslintTester.run('component-limit', rule, {
     valid: [
-        'app.controller("", function() {});',
-        'app.directive("", function() {});',
-        'app.factory("", function() {});',
-        'app.filter("", function() {});',
-        'app.filter("", function() {var emptyArray = [1, 2, 3].filter(function() {});});',
-        'app.provider("", function() {});',
+        'angular.module("").controller("", function() {});',
+        'angular.module("").directive("", function() {});',
+        'angular.module("").factory("", function() {});',
+        'angular.module("").filter("", function() {});',
+        'angular.module("").filter("", function() {var emptyArray = [1, 2, 3].filter(function() {});});',
+        'angular.module("").provider("", function() {});',
         'it("", function() {});it("", function() {});',
         'describe("", function() {it("", function() {});it("", function() {});});',
-        'app.service("", function() {});',
+        'angular.module("").service("", function() {});',
         {
-            code: 'app.controller("", function() {}).directive("", function() {}).factory("", function() {}).filter("", function() {}).provider("", function() {}).service("", function() {});',
+            code: 'angular.module("").controller("", function() {}).directive("", function() {}).factory("", function() {}).filter("", function() {}).provider("", function() {}).service("", function() {});',
             options: [6]
         }
     ].concat(commonFalsePositives),
     invalid: [{
-        code: 'app.controller("", function() {}).directive("", function() {});',
+        code: 'angular.module("").controller("", function() {}).directive("", function() {});',
         errors: [{
             message: 'There may be at most 1 AngularJS component per file, but found 2'
         }]
     }, {
-        code: 'app.factory("", function() {}).filter("", function() {});',
+        code: 'angular.module("").factory("", function() {}).filter("", function() {});',
         errors: [{
             message: 'There may be at most 1 AngularJS component per file, but found 2'
         }]
     }, {
-        code: 'app.provider("", function() {}).service("", function() {});',
+        code: 'angular.module("").provider("", function() {}).service("", function() {});',
         errors: [{
             message: 'There may be at most 1 AngularJS component per file, but found 2'
         }]
     }, {
-        code: 'app.controller("", function() {}).directive("", function() {}).factory("", function() {}).filter("", function() {}).provider("", function() {}).service("", function() {});',
+        code: 'angular.module("").controller("", function() {}).directive("", function() {}).factory("", function() {}).filter("", function() {}).provider("", function() {}).service("", function() {});',
         options: [5],
         errors: [{
             message: 'There may be at most 5 AngularJS components per file, but found 6'

--- a/test/component-limit.js
+++ b/test/component-limit.js
@@ -35,6 +35,11 @@ eslintTester.run('component-limit', rule, {
             message: 'There may be at most 1 AngularJS component per file, but found 2'
         }]
     }, {
+        code: 'angular.module("").animation("", function() {}).filter("", function() {});',
+        errors: [{
+            message: 'There may be at most 1 AngularJS component per file, but found 2'
+        }]
+    }, {
         code: 'angular.module("").factory("", function() {}).filter("", function() {});',
         errors: [{
             message: 'There may be at most 1 AngularJS component per file, but found 2'

--- a/test/di-order.js
+++ b/test/di-order.js
@@ -15,6 +15,7 @@ var commonFalsePositives = require('./utils/commonFalsePositives');
 var eslintTester = new RuleTester();
 eslintTester.run('di-order', rule, {
     valid: [
+        'angular.module("").animation("", function($http, $q) {});',
         'angular.module("").controller("", function($http, $q) {});',
         'angular.module("").directive("", function($http, $q) {});',
         'angular.module("").factory("", function($http, $q) {});',
@@ -33,6 +34,9 @@ eslintTester.run('di-order', rule, {
         }
     ].concat(commonFalsePositives),
     invalid: [{
+        code: 'angular.module("").animation("", function($q, $http) {});',
+        errors: [{message: 'Injected values should be sorted alphabetically'}]
+    }, {
         code: 'angular.module("").controller("", function($q, $http) {});',
         errors: [{message: 'Injected values should be sorted alphabetically'}]
     }, {

--- a/test/di-order.js
+++ b/test/di-order.js
@@ -15,19 +15,17 @@ var commonFalsePositives = require('./utils/commonFalsePositives');
 var eslintTester = new RuleTester();
 eslintTester.run('di-order', rule, {
     valid: [
-        'app.controller("", function($http, $q) {});',
-        'app.directive("", function($http, $q) {});',
-        'app.factory("", function($http, $q) {});',
-        'app.factory("", fsctoryName);',
-        'app.filter("", function($http, $q) {});',
-        'app.provider("", function($http, $q) {});',
-        'app.service("", function($http, $q) {});',
-        'app.config(function($httpProvider, $routeProvider) {});',
-        'app.run(function($http, $q) {});',
+        'angular.module("").controller("", function($http, $q) {});',
+        'angular.module("").directive("", function($http, $q) {});',
+        'angular.module("").factory("", function($http, $q) {});',
+        'angular.module("").factory("", fsctoryName);',
+        'angular.module("").filter("", function($http, $q) {});',
+        'angular.module("").provider("", function($http, $q) {this.$get = function($http, $q) {};});',
+        'angular.module("").service("", function($http, $q) {});',
+        'angular.module("").config(function($httpProvider, $routeProvider) {});',
+        'angular.module("").run(function($http, $q) {});',
         'inject(function($http, $q) {});',
         'it(inject(function($http, $q) {}));',
-        'this.$get = function($http, $q) {};',
-        'this.$get = get;',
         'it(inject(function(_$http_, _$httpBackend_) {}));',
         {
             code: 'it(inject(function(_$httpBackend_, _$http_) {}));',
@@ -35,28 +33,28 @@ eslintTester.run('di-order', rule, {
         }
     ].concat(commonFalsePositives),
     invalid: [{
-        code: 'app.controller("", function($q, $http) {});',
+        code: 'angular.module("").controller("", function($q, $http) {});',
         errors: [{message: 'Injected values should be sorted alphabetically'}]
     }, {
-        code: 'app.directive("", function($q, $http) {});',
+        code: 'angular.module("").directive("", function($q, $http) {});',
         errors: [{message: 'Injected values should be sorted alphabetically'}]
     }, {
-        code: 'app.factory("", function($q, $http) {});',
+        code: 'angular.module("").factory("", function($q, $http) {});',
         errors: [{message: 'Injected values should be sorted alphabetically'}]
     }, {
-        code: 'app.filter("", function($q, $http) {});',
+        code: 'angular.module("").filter("", function($q, $http) {});',
         errors: [{message: 'Injected values should be sorted alphabetically'}]
     }, {
-        code: 'app.provider("", function($q, $http) {});',
+        code: 'angular.module("").provider("", function($q, $http) {});',
         errors: [{message: 'Injected values should be sorted alphabetically'}]
     }, {
-        code: 'app.service("", function($q, $http) {});',
+        code: 'angular.module("").service("", function($q, $http) {});',
         errors: [{message: 'Injected values should be sorted alphabetically'}]
     }, {
-        code: 'app.config(function($routeProvider, $httpProvider) {});',
+        code: 'angular.module("").config(function($routeProvider, $httpProvider) {});',
         errors: [{message: 'Injected values should be sorted alphabetically'}]
     }, {
-        code: 'app.run(function($q, $http) {});',
+        code: 'angular.module("").run(function($q, $http) {});',
         errors: [{message: 'Injected values should be sorted alphabetically'}]
     }, {
         code: 'inject(function($q, $http) {});',
@@ -72,7 +70,7 @@ eslintTester.run('di-order', rule, {
         code: 'it(inject(function(_$httpBackend_, _$http_) {}));',
         errors: [{message: 'Injected values should be sorted alphabetically'}]
     }, {
-        code: 'this.$get = function($q, $http) {};',
+        code: 'angular.module("").provider("", function() {this.$get = function($q, $http) {};});',
         errors: [{message: 'Injected values should be sorted alphabetically'}]
     }]
 });

--- a/test/di-unused.js
+++ b/test/di-unused.js
@@ -38,6 +38,9 @@ eslintTester.run('di-unused', rule, {
         code: 'var app = angular.module(""); app.controller("", function($q) {});',
         errors: [{message: 'Unused injected value $q'}]
     }, {
+        code: 'angular.module("").controller("", LoginController); function LoginController($q) {}',
+        errors: [{message: 'Unused injected value $q'}]
+    }, {
         code: 'angular.module("").directive("", function($q) {});',
         errors: [{message: 'Unused injected value $q'}]
     }, {

--- a/test/di-unused.js
+++ b/test/di-unused.js
@@ -32,6 +32,12 @@ eslintTester.run('di-unused', rule, {
         code: 'angular.module("").controller("", function($q) {});',
         errors: [{message: 'Unused injected value $q'}]
     }, {
+        code: 'var app = angular.module("").controller(""); app.controller("", function($q) {});',
+        errors: [{message: 'Unused injected value $q'}]
+    }, {
+        code: 'var app = angular.module(""); app.controller("", function($q) {});',
+        errors: [{message: 'Unused injected value $q'}]
+    }, {
         code: 'angular.module("").directive("", function($q) {});',
         errors: [{message: 'Unused injected value $q'}]
     }, {

--- a/test/di-unused.js
+++ b/test/di-unused.js
@@ -15,59 +15,59 @@ var commonFalsePositives = require('./utils/commonFalsePositives');
 var eslintTester = new RuleTester();
 eslintTester.run('di-unused', rule, {
     valid: [
-        'app.controller("", function($q) {return $q;});',
-        'app.directive("", function($q) {return $q;});',
-        'app.factory("", function($q) {return $q;});',
-        'app.factory("", function($q) {return function() {return $q;};});',
-        'app.factory("", function() {var myVar;});',
-        'app.filter("", function($q) {return $q;});',
-        'app.provider("", function($httpProvider) {return $httpProvider;});',
-        'app.service("", function($q) {return $q;});',
-        'app.config(function($httpProvider) {$httpProvider.defaults.headers.post.answer="42"})',
-        'app.run(function($q) {$q()})',
+        'angular.module("").controller("", function($q) {return $q;});',
+        'angular.module("").directive("", function($q) {return $q;});',
+        'angular.module("").factory("", function($q) {return $q;});',
+        'angular.module("").factory("", function($q) {return function() {return $q;};});',
+        'angular.module("").factory("", function() {var myVar;});',
+        'angular.module("").filter("", function($q) {return $q;});',
+        'angular.module("").provider("", function($httpProvider) {return $httpProvider;});',
+        'angular.module("").service("", function($q) {return $q;});',
+        'angular.module("").config(function($httpProvider) {$httpProvider.defaults.headers.post.answer="42"})',
+        'angular.module("").run(function($q) {$q()})',
         'inject(function($q) {_$q_ = $q;});',
-        'this.$get = function($q) {return $q;};'
+        'angular.module("").provider("", function() {this.$get = function($q) {return $q};});'
     ].concat(commonFalsePositives),
     invalid: [{
-        code: 'app.controller("", function($q) {});',
+        code: 'angular.module("").controller("", function($q) {});',
         errors: [{message: 'Unused injected value $q'}]
     }, {
-        code: 'app.directive("", function($q) {});',
+        code: 'angular.module("").directive("", function($q) {});',
         errors: [{message: 'Unused injected value $q'}]
     }, {
-        code: 'app.factory("", function($q) {});',
+        code: 'angular.module("").factory("", function($q) {});',
         errors: [{message: 'Unused injected value $q'}]
     }, {
-        code: 'app.factory("", function($http, $q) {});',
+        code: 'angular.module("").factory("", function($http, $q) {});',
         errors: [
             {message: 'Unused injected value $http'},
             {message: 'Unused injected value $q'}
         ]
     }, {
-        code: 'app.factory("", function($http, $q) {return $q.resolve()});',
+        code: 'angular.module("").factory("", function($http, $q) {return $q.resolve()});',
         errors: [
             {message: 'Unused injected value $http'}
         ]
     }, {
-        code: 'app.filter("", function($q) {});',
+        code: 'angular.module("").filter("", function($q) {});',
         errors: [{message: 'Unused injected value $q'}]
     }, {
-        code: 'app.provider("", function($httpProvider) {});',
+        code: 'angular.module("").provider("", function($httpProvider) {});',
         errors: [{message: 'Unused injected value $httpProvider'}]
     }, {
-        code: 'app.service("", function($q) {});',
+        code: 'angular.module("").service("", function($q) {});',
         errors: [{message: 'Unused injected value $q'}]
     }, {
-        code: 'app.config(function($httpProvider) {})',
+        code: 'angular.module("").config(function($httpProvider) {})',
         errors: [{message: 'Unused injected value $httpProvider'}]
     }, {
-        code: 'app.run(function($q) {});',
+        code: 'angular.module("").run(function($q) {});',
         errors: [{message: 'Unused injected value $q'}]
     }, {
         code: 'inject(function($q) {});',
         errors: [{message: 'Unused injected value $q'}]
     }, {
-        code: 'this.$get = function($q) {};',
+        code: 'angular.module("").provider("", function() {this.$get = function($q) {};});',
         errors: [{message: 'Unused injected value $q'}]
     }]
 });

--- a/test/di-unused.js
+++ b/test/di-unused.js
@@ -16,6 +16,7 @@ var eslintTester = new RuleTester();
 eslintTester.run('di-unused', rule, {
     valid: [
         'angular.module("").controller("", function($q) {return $q;});',
+        'angular.module("").animation("", function($q) {return $q;});',
         'angular.module("").directive("", function($q) {return $q;});',
         'angular.module("").factory("", function($q) {return $q;});',
         'angular.module("").factory("", function($q) {return function() {return $q;};});',
@@ -29,6 +30,9 @@ eslintTester.run('di-unused', rule, {
         'angular.module("").provider("", function() {this.$get = function($q) {return $q};});'
     ].concat(commonFalsePositives),
     invalid: [{
+        code: 'angular.module("").animation("", function($q) {});',
+        errors: [{message: 'Unused injected value $q'}]
+    }, {
         code: 'angular.module("").controller("", function($q) {});',
         errors: [{message: 'Unused injected value $q'}]
     }, {


### PR DESCRIPTION
I'm writing a rule wrapper which makes it easier to write some AngularJS related rules.

The goal is that common rule definitions don't have to implement the same common checks and lookups individually. Also this should help fixing common false positives.

Ultimately I think it is possible to achieve a wrapper which can resolve variables using ESLint scopes and understands the following are AngularJS components:
```js
var myApp = angular.module('myApp').factory('toyFactory', function() {});

myApp.filter('parentalControl', parentalControlFilter);

function parentalControlFilter() {}
```

Whereas these are not:
```js
_.filter(obj, coffeeFilter);

mocha.run();
```
Currently the component extraction is handled by each rule separately, which grealy impacts performance. For this reason this PR should not be merged yet.

I think this can be shared eventually. This way it might even become more performant than not using this rule, because many checks can be skipped in the rule definitions themselves.

For demo purposes I have ported `di-order` and `di-unused` to use this new setup.

@Gillespie59 @tilmanpotthof do you guys think this is a good approach?