### PR TITLE
feat(di-unused): check unused deps in array notation

### DIFF
--- a/rules/di-unused.js
+++ b/rules/di-unused.js
@@ -41,6 +41,12 @@ module.exports = function(context) {
         AssignmentExpression: function(node) {
             // Colllect the $get function of a providers.
             if (node.left.type === 'MemberExpression' && node.left.property.name === '$get') {
+                if (node.right.type === 'ArrayExpression') {
+                    return injectFunctions.push({
+                        node: node.right.elements[node.right.elements.length - 1]
+                    });
+                }
+
                 injectFunctions.push({
                     node: node.right
                 });
@@ -49,22 +55,48 @@ module.exports = function(context) {
 
         CallExpression: function(node) {
             // An Angular component definition.
-            if (utils.isAngularComponent(node) && node.callee.type === 'MemberExpression' && node.arguments[1].type === 'FunctionExpression' && angularNamedObjectList.indexOf(node.callee.property.name) >= 0) {
-                return injectFunctions.push({
-                    node: node.arguments[1]
-                });
+            if (utils.isAngularComponent(node) && node.callee.type === 'MemberExpression' && angularNamedObjectList.indexOf(node.callee.property.name) >= 0) {
+                if (node.arguments[1].type === 'FunctionExpression') {
+                    return injectFunctions.push({
+                        node: node.arguments[1]
+                    });
+                }
+
+                if (node.arguments[1].type === 'ArrayExpression') {
+                    return injectFunctions.push({
+                        node: node.arguments[1].elements[node.arguments[1].elements.length - 1]
+                    });
+                }
             }
+
             // Config and run functions.
-            if (node.callee.type === 'MemberExpression' && node.arguments.length > 0 && setupCalls.indexOf(node.callee.property.name) !== -1 && node.arguments[0].type === 'FunctionExpression') {
-                return injectFunctions.push({
-                    node: node.arguments[0]
-                });
+            if (node.callee.type === 'MemberExpression' && node.arguments.length > 0 && setupCalls.indexOf(node.callee.property.name) !== -1) {
+                if (node.arguments[0].type === 'FunctionExpression') {
+                    return injectFunctions.push({
+                        node: node.arguments[0]
+                    });
+                }
+
+                if (node.arguments[0].type === 'ArrayExpression') {
+                    return injectFunctions.push({
+                        node: node.arguments[0].elements[node.arguments[0].elements.length - 1]
+                    });
+                }
             }
+
             // Injected values in unittests.
             if (node.callee.type === 'Identifier' && node.callee.name === 'inject') {
-                return injectFunctions.push({
-                    node: node.arguments[0]
-                });
+                if (node.arguments[0].type === 'FunctionExpression') {
+                    return injectFunctions.push({
+                        node: node.arguments[0]
+                    });
+                }
+
+                if (node.arguments[0].type === 'ArrayExpression') {
+                    return injectFunctions.push({
+                        node: node.arguments[0].elements[node.arguments[0].elements.length - 1]
+                    });
+                }
             }
         },
 

--- a/test/di-unused.js
+++ b/test/di-unused.js
@@ -15,29 +15,67 @@ var eslintTester = new RuleTester();
 eslintTester.run('di-unused', rule, {
     valid: [
         'app.controller("", function($q) {return $q;});',
+        'app.controller("", ["$q", function($q) {return $q;}]);',
+
         'app.directive("", function($q) {return $q;});',
+        'app.directive("", ["$q", function($q) {return $q;}]);',
+
         'app.factory("", function($q) {return $q;});',
+        'app.factory("", ["$q", function($q) {return $q;}]);',
+
         'app.factory("", function($q) {return function() {return $q;};});',
+        'app.factory("", ["$q", function($q) {return function() {return $q;};}]);',
+
         'app.factory("", function() {var myVar;});',
+        'app.factory("", [function() {var myVar;}]);',
+
         'app.filter("", function($q) {return $q;});',
+        'app.filter("", ["$q", function($q) {return $q;}]);',
+
         'app.provider("", function($httpProvider) {return $httpProvider;});',
+        'app.provider("", ["$httpProvider", function($httpProvider) {return $httpProvider;}]);',
+
         'app.service("", function($q) {return $q;});',
+        'app.service("", ["$q", function($q) {return $q;}]);',
+
         'app.config(function($httpProvider) {$httpProvider.defaults.headers.post.answer="42"})',
+        'app.config(["$httpProvider", function($httpProvider) {$httpProvider.defaults.headers.post.answer="42"}])',
+
         'app.run(function($q) {$q()})',
+        'app.run(["$q", function($q) {$q()}])',
+
         'inject(function($q) {_$q_ = $q;});',
-        'this.$get = function($q) {return $q;};'
+        'inject(["$q", function($q) {_$q_ = $q;}]);',
+
+        'this.$get = function($q) {return $q;};',
+        'this.$get = ["$q", function($q) {return $q;}];'
     ],
     invalid: [{
         code: 'app.controller("", function($q) {});',
         errors: [{message: 'Unused injected value $q'}]
     }, {
+        code: 'app.controller("", ["$q", function($q) {}]);',
+        errors: [{message: 'Unused injected value $q'}]
+    }, {
         code: 'app.directive("", function($q) {});',
+        errors: [{message: 'Unused injected value $q'}]
+    }, {
+        code: 'app.directive("", ["$q", function($q) {}]);',
         errors: [{message: 'Unused injected value $q'}]
     }, {
         code: 'app.factory("", function($q) {});',
         errors: [{message: 'Unused injected value $q'}]
     }, {
+        code: 'app.factory("", ["$q", function($q) {}]);',
+        errors: [{message: 'Unused injected value $q'}]
+    }, {
         code: 'app.factory("", function($http, $q) {});',
+        errors: [
+            {message: 'Unused injected value $http'},
+            {message: 'Unused injected value $q'}
+        ]
+    }, {
+        code: 'app.factory("", ["$http", "$q", function($http, $q) {}]);',
         errors: [
             {message: 'Unused injected value $http'},
             {message: 'Unused injected value $q'}
@@ -51,22 +89,43 @@ eslintTester.run('di-unused', rule, {
         code: 'app.filter("", function($q) {});',
         errors: [{message: 'Unused injected value $q'}]
     }, {
+        code: 'app.filter("", ["$q", function($q) {}]);',
+        errors: [{message: 'Unused injected value $q'}]
+    }, {
         code: 'app.provider("", function($httpProvider) {});',
+        errors: [{message: 'Unused injected value $httpProvider'}]
+    }, {
+        code: 'app.provider("", ["$httpProvider", function($httpProvider) {}]);',
         errors: [{message: 'Unused injected value $httpProvider'}]
     }, {
         code: 'app.service("", function($q) {});',
         errors: [{message: 'Unused injected value $q'}]
     }, {
+        code: 'app.service("", ["$q", function($q) {}]);',
+        errors: [{message: 'Unused injected value $q'}]
+    }, {
         code: 'app.config(function($httpProvider) {})',
+        errors: [{message: 'Unused injected value $httpProvider'}]
+    }, {
+        code: 'app.config(["$httpProvider", function($httpProvider) {}])',
         errors: [{message: 'Unused injected value $httpProvider'}]
     }, {
         code: 'app.run(function($q) {});',
         errors: [{message: 'Unused injected value $q'}]
     }, {
+        code: 'app.run(["$q", function($q) {}]);',
+        errors: [{message: 'Unused injected value $q'}]
+    }, {
         code: 'inject(function($q) {});',
         errors: [{message: 'Unused injected value $q'}]
     }, {
+        code: 'inject(["$q", function($q) {}]);',
+        errors: [{message: 'Unused injected value $q'}]
+    }, {
         code: 'this.$get = function($q) {};',
+        errors: [{message: 'Unused injected value $q'}]
+    }, {
+        code: 'this.$get = ["$q", function($q) {}];',
         errors: [{message: 'Unused injected value $q'}]
     }]
 });


### PR DESCRIPTION
Now di-unused does not check usage of deps if we rite in array notation our services:

```js

angular.module('foo', []).controller('MyController', ['$http', function($http){...}]);
```

this patch should fix it.

Thanks!