### PR TITLE
Check injected functions using array notation

### DIFF
--- a/test/di-order.js
+++ b/test/di-order.js
@@ -37,34 +37,67 @@ eslintTester.run('di-order', rule, {
         code: 'angular.module("").animation("", function($q, $http) {});',
         errors: [{message: 'Injected values should be sorted alphabetically'}]
     }, {
+        code: 'angular.module("").animation("", ["q", "$http", function($q, $http) {}]);',
+        errors: [{message: 'Injected values should be sorted alphabetically'}]
+    }, {
         code: 'angular.module("").controller("", function($q, $http) {});',
+        errors: [{message: 'Injected values should be sorted alphabetically'}]
+    }, {
+        code: 'angular.module("").controller("", ["q", "$http", function($q, $http) {}]);',
         errors: [{message: 'Injected values should be sorted alphabetically'}]
     }, {
         code: 'angular.module("").directive("", function($q, $http) {});',
         errors: [{message: 'Injected values should be sorted alphabetically'}]
     }, {
+        code: 'angular.module("").directive("", ["q", "$http", function($q, $http) {}]);',
+        errors: [{message: 'Injected values should be sorted alphabetically'}]
+    }, {
         code: 'angular.module("").factory("", function($q, $http) {});',
+        errors: [{message: 'Injected values should be sorted alphabetically'}]
+    }, {
+        code: 'angular.module("").factory("", ["q", "$http", function($q, $http) {}]);',
         errors: [{message: 'Injected values should be sorted alphabetically'}]
     }, {
         code: 'angular.module("").filter("", function($q, $http) {});',
         errors: [{message: 'Injected values should be sorted alphabetically'}]
     }, {
+        code: 'angular.module("").filter("", ["q", "$http", function($q, $http) {}]);',
+        errors: [{message: 'Injected values should be sorted alphabetically'}]
+    }, {
         code: 'angular.module("").provider("", function($q, $http) {});',
+        errors: [{message: 'Injected values should be sorted alphabetically'}]
+    }, {
+        code: 'angular.module("").provider("", ["q", "$http", function($q, $http) {}]);',
         errors: [{message: 'Injected values should be sorted alphabetically'}]
     }, {
         code: 'angular.module("").service("", function($q, $http) {});',
         errors: [{message: 'Injected values should be sorted alphabetically'}]
     }, {
+        code: 'angular.module("").service("", ["q", "$http", function($q, $http) {}]);',
+        errors: [{message: 'Injected values should be sorted alphabetically'}]
+    }, {
         code: 'angular.module("").config(function($routeProvider, $httpProvider) {});',
+        errors: [{message: 'Injected values should be sorted alphabetically'}]
+    }, {
+        code: 'angular.module("").config(["$routeProvider", "$httpProvider", function($routeProvider, $httpProvider) {}]);',
         errors: [{message: 'Injected values should be sorted alphabetically'}]
     }, {
         code: 'angular.module("").run(function($q, $http) {});',
         errors: [{message: 'Injected values should be sorted alphabetically'}]
     }, {
+        code: 'angular.module("").run(["q", "$http", function($q, $http) {}]);',
+        errors: [{message: 'Injected values should be sorted alphabetically'}]
+    }, {
         code: 'inject(function($q, $http) {});',
         errors: [{message: 'Injected values should be sorted alphabetically'}]
     }, {
+        code: 'inject(["q", "$http", function($q, $http) {}]);',
+        errors: [{message: 'Injected values should be sorted alphabetically'}]
+    }, {
         code: 'it(inject(function($q, $http) {}));',
+        errors: [{message: 'Injected values should be sorted alphabetically'}]
+    }, {
+        code: 'it(inject(["q", "$http", function($q, $http) {}]));',
         errors: [{message: 'Injected values should be sorted alphabetically'}]
     }, {
         code: 'it(inject(function(_$http_, _$httpBackend_) {}));',
@@ -75,6 +108,9 @@ eslintTester.run('di-order', rule, {
         errors: [{message: 'Injected values should be sorted alphabetically'}]
     }, {
         code: 'angular.module("").provider("", function() {this.$get = function($q, $http) {};});',
+        errors: [{message: 'Injected values should be sorted alphabetically'}]
+    }, {
+        code: 'angular.module("").provider("", function() {this.$get = ["$q", "$http", function($q, $http) {}];});',
         errors: [{message: 'Injected values should be sorted alphabetically'}]
     }]
 });

--- a/test/di-unused.js
+++ b/test/di-unused.js
@@ -16,24 +16,40 @@ var eslintTester = new RuleTester();
 eslintTester.run('di-unused', rule, {
     valid: [
         'angular.module("").controller("", function($q) {return $q;});',
+        'angular.module("").controller("", ["$q", function($q) {return $q;}]);',
         'angular.module("").animation("", function($q) {return $q;});',
+        'angular.module("").animation("", ["$q", function($q) {return $q;}]);',
         'angular.module("").directive("", function($q) {return $q;});',
+        'angular.module("").directive("", ["$q", function($q) {return $q;}]);',
         'angular.module("").factory("", function($q) {return $q;});',
+        'angular.module("").factory("", ["$q", function($q) {return $q;}]);',
         'angular.module("").factory("", function($q) {return function() {return $q;};});',
         'angular.module("").factory("", function() {var myVar;});',
         'angular.module("").filter("", function($q) {return $q;});',
+        'angular.module("").filter("", ["$q", function($q) {return $q;}]);',
         'angular.module("").provider("", function($httpProvider) {return $httpProvider;});',
+        'angular.module("").provider("", ["$$httpProvider", function($$httpProvider) {return $$httpProvider;}]);',
         'angular.module("").service("", function($q) {return $q;});',
+        'angular.module("").service("", ["$q", function($q) {return $q;}]);',
         'angular.module("").config(function($httpProvider) {$httpProvider.defaults.headers.post.answer="42"})',
+        'angular.module("").config(["$httpProvider", function($httpProvider) {$httpProvider.defaults.headers.post.answer="42"}]);',
         'angular.module("").run(function($q) {$q()})',
+        'angular.module("").run(["$q", function($q) {return $q;}]);',
         'inject(function($q) {_$q_ = $q;});',
-        'angular.module("").provider("", function() {this.$get = function($q) {return $q};});'
+        'angular.module("").provider("", function() {this.$get = function($q) {return $q};});',
+        'angular.module("").provider("", function() {this.$get = ["$q", function($q) {return $q}];});'
     ].concat(commonFalsePositives),
     invalid: [{
         code: 'angular.module("").animation("", function($q) {});',
         errors: [{message: 'Unused injected value $q'}]
     }, {
+        code: 'angular.module("").animation("", ["q", function($q) {}]);',
+        errors: [{message: 'Unused injected value $q'}]
+    }, {
         code: 'angular.module("").controller("", function($q) {});',
+        errors: [{message: 'Unused injected value $q'}]
+    }, {
+        code: 'angular.module("").controller("", ["q", function($q) {}]);',
         errors: [{message: 'Unused injected value $q'}]
     }, {
         code: 'var app = angular.module("").controller(""); app.controller("", function($q) {});',
@@ -48,7 +64,13 @@ eslintTester.run('di-unused', rule, {
         code: 'angular.module("").directive("", function($q) {});',
         errors: [{message: 'Unused injected value $q'}]
     }, {
+        code: 'angular.module("").directive("", ["q", function($q) {}]);',
+        errors: [{message: 'Unused injected value $q'}]
+    }, {
         code: 'angular.module("").factory("", function($q) {});',
+        errors: [{message: 'Unused injected value $q'}]
+    }, {
+        code: 'angular.module("").factory("", ["q", function($q) {}]);',
         errors: [{message: 'Unused injected value $q'}]
     }, {
         code: 'angular.module("").factory("", function($http, $q) {});',
@@ -65,22 +87,43 @@ eslintTester.run('di-unused', rule, {
         code: 'angular.module("").filter("", function($q) {});',
         errors: [{message: 'Unused injected value $q'}]
     }, {
+        code: 'angular.module("").filter("", ["q", function($q) {}]);',
+        errors: [{message: 'Unused injected value $q'}]
+    }, {
         code: 'angular.module("").provider("", function($httpProvider) {});',
         errors: [{message: 'Unused injected value $httpProvider'}]
     }, {
+        code: 'angular.module("").provider("", ["q", function($q) {}]);',
+        errors: [{message: 'Unused injected value $q'}]
+    }, {
         code: 'angular.module("").service("", function($q) {});',
+        errors: [{message: 'Unused injected value $q'}]
+    }, {
+        code: 'angular.module("").service("", ["q", function($q) {}]);',
         errors: [{message: 'Unused injected value $q'}]
     }, {
         code: 'angular.module("").config(function($httpProvider) {})',
         errors: [{message: 'Unused injected value $httpProvider'}]
     }, {
+        code: 'angular.module("").config(["q", function($q) {}]);',
+        errors: [{message: 'Unused injected value $q'}]
+    }, {
         code: 'angular.module("").run(function($q) {});',
+        errors: [{message: 'Unused injected value $q'}]
+    }, {
+        code: 'angular.module("").run(["q", function($q) {}]);',
         errors: [{message: 'Unused injected value $q'}]
     }, {
         code: 'inject(function($q) {});',
         errors: [{message: 'Unused injected value $q'}]
     }, {
+        code: 'inject(["q", function($q) {}]);',
+        errors: [{message: 'Unused injected value $q'}]
+    }, {
         code: 'angular.module("").provider("", function() {this.$get = function($q) {};});',
+        errors: [{message: 'Unused injected value $q'}]
+    }, {
+        code: 'angular.module("").provider("", function() {this.$get = ["q", function($q) {}];});',
         errors: [{message: 'Unused injected value $q'}]
     }]
 });


### PR DESCRIPTION
This affects the rules `di-order` and `di-unused`.

This fixes the same issue as #277, but using `angularRule`.