### PR TITLE
Change isAngularComponent to also capture require("")

### DIFF
--- a/rules/utils/utils.js
+++ b/rules/utils/utils.js
@@ -193,7 +193,7 @@ function isLiteralType(node) {
  * Check whether or not a node is a CallExpression.
  *
  * @param {Object} node The node to check.
- * @returns {boolean} Whether or not the node is an Literal.
+ * @returns {boolean} Whether or not the node is a CallExpression.
  */
 function isCallExpression(node) {
     return node !== undefined && node.type === 'CallExpression';

--- a/rules/utils/utils.js
+++ b/rules/utils/utils.js
@@ -190,6 +190,16 @@ function isLiteralType(node) {
 }
 
 /**
+ * Check whether or not a node is a CallExpression.
+ *
+ * @param {Object} node The node to check.
+ * @returns {boolean} Whether or not the node is an Literal.
+ */
+function isCallExpression(node) {
+    return node !== undefined && node.type === 'CallExpression';
+}
+
+/**
  * Check whether or not a node is an isEmptyFunction.
  *
  * @param {Object} node The node to check.
@@ -237,7 +247,8 @@ function isAngularComponent(node) {
         isLiteralType(node.arguments[0]) &&
         (isIdentifierType(node.arguments[1]) ||
          isFunctionType(node.arguments[1]) ||
-         isArrayType(node.arguments[1]));
+         isArrayType(node.arguments[1]) ||
+         isCallExpression(node.arguments[1]));
 }
 
 /**

--- a/rules/utils/utils.js
+++ b/rules/utils/utils.js
@@ -232,6 +232,8 @@ function isStringRegexp(string) {
  *     ^^^^^^^
  * app.factory('kittenService', [])
  *     ^^^^^^^
+ * app.factory('kittenService', require(""))
+ *     ^^^^^^^
  * asyncFn('value', callback)
  * ^^^^^^^
  * ```

--- a/test/directive-name.js
+++ b/test/directive-name.js
@@ -34,6 +34,10 @@ eslintTester.run('directive-name', rule, {
         code: 'app.directive("Directive", function() {});',
         options: ['eslint'],
         settings: {angular: 2}
+    }, {
+        code: 'app.directive("eslintDirective", require(""));',
+        options: ['/^eslint/'],
+        settings: {angular: 1}
     }].concat(commonFalsePositives),
     invalid: [
         {

--- a/test/filter-name.js
+++ b/test/filter-name.js
@@ -26,6 +26,9 @@ eslintTester.run('filter-name', rule, {
     }, {
         code: 'app.filter("eslintFilter", function() {});',
         options: ['/^eslint/']
+    }, {
+        code: 'app.filter("eslintFilter", require(""));',
+        options: ['eslint']
     }].concat(commonFalsePositives),
     invalid: [
         {

--- a/test/no-controller.js
+++ b/test/no-controller.js
@@ -20,6 +20,7 @@ eslintTester.run('no-controller', rule, {
     ].concat(commonFalsePositives),
     invalid: [
         {code: 'app.controller("", function() {})', errors: [{message: 'Based on the Component-First Pattern, you should avoid the use of controllers'}]},
-        {code: 'angular.module("").controller("", function() {})', errors: [{message: 'Based on the Component-First Pattern, you should avoid the use of controllers'}]}
+        {code: 'angular.module("").controller("", function() {})', errors: [{message: 'Based on the Component-First Pattern, you should avoid the use of controllers'}]},
+        {code: 'app.controller("", require(""))', errors: [{message: 'Based on the Component-First Pattern, you should avoid the use of controllers'}]}
     ]
 });

--- a/test/no-service-method.js
+++ b/test/no-service-method.js
@@ -33,6 +33,9 @@ eslintTester.run('no-service-method', rule, {
         code: 'app.service("Service", function() {});',
         errors: [{message: 'You should prefer the factory() method instead of service()'}]
     }, {
+        code: 'app.service("Service", require(""));',
+        errors: [{message: 'You should prefer the factory() method instead of service()'}]
+    }, {
         code: 'app.service("Service", [function() {}]);',
         errors: [{message: 'You should prefer the factory() method instead of service()'}]
     }]


### PR DESCRIPTION
When using Angular with Browserify, or another module loader system, the linter should be able to dectect components that are required from another file. 
Expanded the isAngularComponent method to also allow CallExpression nodes.