### PR TITLE
Enfore eslint rule global-require

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -118,6 +118,7 @@ rules:
 
   # http://eslint.org/docs/rules/#nodejs
   callback-return: 2
+  global-require: 2
   handle-callback-err:
     - 2
     - ^(e|err|error)$

--- a/rules/file-name.js
+++ b/rules/file-name.js
@@ -13,10 +13,11 @@
  */
 'use strict';
 
+var path = require('path');
+
 var utils = require('./utils/utils');
 
 module.exports = (function() {
-    var path = require('path');
     var fileEnding = '.js';
 
     var separators = {

--- a/rules/utils/rulesConfiguration.js
+++ b/rules/utils/rulesConfiguration.js
@@ -3,7 +3,7 @@
 function Rule(name, config) {
     this.name = name;
     this.config = config;
-    this._requireRule = require('../' + this.name);
+    this._requireRule = require('../' + this.name);  // eslint-disable-line global-require
 }
 
 Rule.prototype = {

--- a/scripts/docs.js
+++ b/scripts/docs.js
@@ -3,7 +3,8 @@
 var fs = require('fs');
 var parseComments = require('parse-comments');
 var _ = require('lodash');
-var eslintAngularIndex = require('../index.js');
+var eslintAngularIndex = require('../index');
+var ruleCategories = require('./ruleCategories.json');
 var RuleTester = require('eslint').RuleTester;
 
 var templates = require('./templates.js');
@@ -41,8 +42,6 @@ function createDocFiles(cb) {
  * @param cb callback
  */
 function updateReadme(readmePath, cb) {
-    var ruleCategories = require('./ruleCategories.json');
-
     ruleCategories.rulesByCategory = _.groupBy(this.rules, 'category');
 
     // filter categories without rules
@@ -192,7 +191,7 @@ function _createRule(ruleName) {
     }
 
     // load rule module for tests
-    rule.module = require('../rules/' + rule.ruleName);
+    rule.module = require('../rules/' + rule.ruleName);  // eslint-disable-line global-require
 
     // load examples, prepare them for the tests and group the for the template
     rule.allExamples = _loadExamples(rule);


### PR DESCRIPTION
I figured enforcing `global-require` makes sense. On the other hand I have my doubts, since it adds some `eslint-disable-line` comments as well.

@tilmanpotthof Feel free to either merge or close this.