### PR TITLE
Add contributors to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,11 @@
     "type": "git",
     "url": "https://github.com/Gillespie59/eslint-plugin-angularjs.git"
   },
-  "author": "Emmanuel DEMEY",
+  "contributors": [
+    "Emmanuel Demey (http://gillespie59.github.io/)",
+    "Tilman Potthof (https://github.com/tilmanpotthof)",
+    "Remco Haszing (https://github.com/remcohaszing)"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/Gillespie59/eslint-plugin-angularjs/issues"


### PR DESCRIPTION
This closes #316.

If I'm correct, the `contributors` field should replace `author`. (https://docs.npmjs.com/files/package.json#people-fields-author-contributors)