### PR TITLE
Update directive-restrict rule to support restriction by Class

### DIFF
--- a/rules/directive-restrict.js
+++ b/rules/directive-restrict.js
@@ -96,7 +96,7 @@ module.exports.schema = [{
     properties: {
         restrict: {
             type: 'string',
-            pattern: '^A|C|E|(AC)|(CA)(AE)|(EA)(EC)|(CE)|(AEC)|(ACE)|(EAC)|(CAE)|(ACE)|(AEC)|(CAE)|(ACE)|(AEC)$'
+            pattern: '^A|C|E|(AC)|(CA)|(AE)|(EA)|(EC)|(CE)|(AEC)|(ACE)|(EAC)|(CAE)|(ACE)|(AEC)|(CAE)|(ACE)|(AEC)$'
         },
         explicit: {
             enum: ['always', 'never']

--- a/rules/directive-restrict.js
+++ b/rules/directive-restrict.js
@@ -96,7 +96,7 @@ module.exports.schema = [{
     properties: {
         restrict: {
             type: 'string',
-            pattern: '^A|E|(AE)|(EA)$'
+            pattern: '^A|C|E|(AC)|(CA)(AE)|(EA)(EC)|(CE)|(AEC)|(ACE)|(EAC)|(CAE)|(ACE)|(AEC)|(CAE)|(ACE)|(AEC)$'
         },
         explicit: {
             enum: ['always', 'never']

--- a/test/directive-restrict.js
+++ b/test/directive-restrict.js
@@ -40,6 +40,12 @@ eslintTester.run('directive-restrict', rule, {
             code: 'app.directive("", function() {return {restrict:"EA"}})',
             options: [{restrict: 'EA', explicit: 'always'}]
         }, {
+            code: 'app.directive("", function() {return {restrict:"AC"}})',
+            options: [{restrict: 'AC', explicit: 'always'}]
+        }, {
+            code: 'app.directive("", function() {return {restrict:"AEC"}})',
+            options: [{restrict: 'AEC', explicit: 'always'}]
+        }, {
             code: 'app.directive("", function() {directive = {restrict:"A"}; return directive})',
             options: [{explicit: 'always'}]
         }, {
@@ -78,6 +84,12 @@ eslintTester.run('directive-restrict', rule, {
             code: 'app.directive("", function() {return {restrict:"EA"}})',
             options: [{restrict: 'AE', explicit: 'always'}],
             errors: [{message: 'Disallowed directive restriction. It must be one of AE in that order'}]
+        },
+        // Disallowed with wrong order
+        {
+            code: 'app.directive("", function() {return {restrict:"CEA"}})',
+            options: [{restrict: 'AEC', explicit: 'always'}],
+            errors: [{message: 'Disallowed directive restriction. It must be one of AEC in that order'}]
         },
         // Disallowed with explicit restrict
         {


### PR DESCRIPTION
First of all, I think you all have done an awesome work here, so Congrats.

Now the reason for this PR is because for an eCommerce app I'm working on we need to support IE8, so short story is that we need to restrict directive by Attribute and / or Class only so I found this plugin which has a lot of good rules, specially directive-restrict one which has pretty much most of what I need but it as some limitations ( by design ) as it follows {johnpapa} `y074` Restrict to Elements and Attributes guideline. So I made some changes so it still support's johnpapa rule plus a way to "bend" a bit the restriction list to accommodate more scenarios like the one I have.

More information on angular directive and IE8 issues here: http://stackoverflow.com/questions/19611280/directive-not-working-in-ie8

If it does not make sense for you guys, that is ok, I can still use my small custom version in my project(s). Happy to update documentation for this rule if you are happy with it. 

@tilmanpotthof 
@Gillespie59
@remcohaszing 