### PR TITLE
$on('destroy',...) rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Users may use the shareable [eslint-config-angular](https://github.com/dustinspe
         "angular/no-services": [2, ["$http", "$resource", "Restangular", "$q"]],
         "angular/no-service-method": 2,
         "angular/on-watch": 2,
+        "angular/on-destroy": 2,
         "angular/one-dependency-per-line": 0,
         "angular/rest-service": 0,
         "angular/service-name": 0,

--- a/docs/on-destroy.md
+++ b/docs/on-destroy.md
@@ -1,0 +1,39 @@
+<!-- WARNING: Generated documentation. Edit docs and examples in the rule and examples file ('rules/on-destroy.js', 'examples/on-destroy.js'). -->
+
+# on-destroy - Check for common misspelling $on('destroy', ...).
+
+It should be $on('$destroy', ...).
+
+## Examples
+
+The following patterns are considered problems;
+
+    /*eslint angular/on-destroy: 2*/
+
+    // invalid
+    $rootScope.$on('destroy', function () {
+        // ...
+    }); // error: You probably misspelled $on("$destroy").
+
+The following patterns are **not** considered problems;
+
+    /*eslint angular/on-destroy: 2*/
+
+    // valid
+    $scope.$on('$destroy', function () {
+        // ...
+    });
+
+    // valid
+    var unregister = $rootScope.$on('$destroy', function () {
+        // ...
+    });
+
+## Version
+
+This rule was introduced in eslint-plugin-angular 0.1.0
+
+## Links
+
+* [Rule source](../rules/on-destroy.js)
+* [Example source](../examples/on-destroy.js)

--- a/examples/on-destroy.js
+++ b/examples/on-destroy.js
@@ -1,0 +1,14 @@
+// example - valid: true
+$scope.$on('$destroy', function () {
+    // ...
+});
+
+// example - valid: true
+var unregister = $rootScope.$on('$destroy', function () {
+    // ...
+});
+
+// example - valid: false, errorMessage: "You probably misspelled $on(\"$destroy\")."
+$rootScope.$on('destroy', function () {
+    // ...
+});

--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ rulesConfiguration.addRule('no-run-logic', 0);
 rulesConfiguration.addRule('no-services', [2, ['$http', '$resource', 'Restangular', '$q']]);
 rulesConfiguration.addRule('no-service-method', 2);
 rulesConfiguration.addRule('on-watch', 2);
+rulesConfiguration.addRule('on-destroy', 2);
 rulesConfiguration.addRule('one-dependency-per-line', 0);
 rulesConfiguration.addRule('rest-service', 0);
 rulesConfiguration.addRule('service-name', 0);

--- a/rules/on-destroy.js
+++ b/rules/on-destroy.js
@@ -1,0 +1,60 @@
+/**
+ * Check for common misspelling $on('destroy', ...).
+ *
+ * It should be $on('$destroy', ...).
+ * @version 0.1.0
+ * @category misspelling
+ */
+'use strict';
+
+module.exports = function(context) {
+    function report(node) {
+        context.report(node, 'You probably misspelled $on("$destroy").');
+    }
+
+    /**
+     * Return true if the given node is a call expression calling a function
+     * named '$on'.
+     */
+    function isOn(node) {
+        var calledFunction = node.callee;
+        if (calledFunction.type !== 'MemberExpression') {
+            return false;
+        }
+
+        // can only easily tell what name was used if a simple
+        // identifiers were used to access it.
+        var accessedFunction = calledFunction.property;
+        if (accessedFunction.type !== 'Identifier') {
+            return false;
+        }
+
+        var functionName = accessedFunction.name;
+
+        return functionName === '$on';
+    }
+
+    /**
+     * Return true if the given node is a call expression that has a first
+     * argument of the string '$destroy'.
+     */
+    function isFirstArgDestroy(node) {
+        var args = node.arguments;
+
+        return (args.length >= 1 &&
+                args[0].type === 'Literal' &&
+                args[0].value === 'destroy');
+    }
+
+    return {
+        CallExpression: function(node) {
+            if (isOn(node) && isFirstArgDestroy(node)) {
+                report(node);
+            }
+        }
+    };
+};
+
+module.exports.schema = [
+    // JSON Schema for rule options goes here
+];

--- a/test/on-destroy.js
+++ b/test/on-destroy.js
@@ -1,0 +1,48 @@
+'use strict';
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+var rule = require('../rules/on-destroy');
+var RuleTester = require('eslint').RuleTester;
+var commonFalsePositives = require('./utils/commonFalsePositives');
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+var eslintTester = new RuleTester();
+
+eslintTester.run('on-destroy', rule, {
+    valid: [
+        'var variable = scope.$on()',
+        'var variable = scope.$watch()',
+        'var variable = $scope.$on()',
+        'var variable = $scope.$watch()',
+        'var variable = $rootScope.$on()',
+        'var variable = $rootScope.$watch()',
+        '$scope.$on("$destroy")',
+        '$rootScope.$on("$destroy")',
+        '$scope.$on("$destroy", $scope.$on())',
+        '$rootScope.$on("$destroy", $scope.$on())',
+        '$scope.$on("$destroy", $rootScope.$on())',
+        '$rootScope.$on("$destroy", $rootScope.$on())',
+        'scope.$on()',
+        'scope.$watch()',
+        '$scope.$on()',
+        '$scope.$watch()',
+        'scope.$on("$destroy")',
+        '$rootScope.$on("$destroy")',
+
+        // false positive check
+        '$on()',
+
+        // uncovered edgecase
+        '$scope["$on"]()'
+    ].concat(commonFalsePositives),
+    invalid: [
+        {code: '$rootScope.$on("destroy")', errors: [{message: 'You probably misspelled $on("$destroy").'}]},
+        {code: 'scope.$on("destroy")', errors: [{message: 'You probably misspelled $on("$destroy").'}]}
+    ]
+});


### PR DESCRIPTION
The common misspelling `$on('destroy')` causes memory leaks and is hard to test (since it requires testing for memory leaks).

Eslint rule is a good way to deal with this problem.