### PR TITLE
Remove default configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Users may use the shareable [eslint-config-angular](https://github.com/dustinspe
         "angular/controller-as": 0,
         "angular/controller-as-route": 0,
         "angular/controller-as-vm": [0, "vm"],
-        "angular/controller-name": [0, "/[A-Z].*Controller$/"],
+        "angular/controller-name": 0,
         "angular/deferred": 0,
         "angular/definedundefined": 0,
         "angular/di": [0, "function"],

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ rulesConfiguration.addRule('component-limit', [0, 1]);
 rulesConfiguration.addRule('controller-as', 0);
 rulesConfiguration.addRule('controller-as-route', 0);
 rulesConfiguration.addRule('controller-as-vm', [0, 'vm']);
-rulesConfiguration.addRule('controller-name', [0, /[A-Z].*Controller$/]);
+rulesConfiguration.addRule('controller-name', 0);
 rulesConfiguration.addRule('deferred', 0);
 rulesConfiguration.addRule('definedundefined', 0);
 rulesConfiguration.addRule('di', [0, 'function']);

--- a/rules/controller-name.js
+++ b/rules/controller-name.js
@@ -18,12 +18,8 @@ module.exports = function(context) {
     return {
 
         CallExpression: function(node) {
-            var prefix = context.options[0];
+            var prefix = context.options[0] || '/[A-Z].*Controller$/';
             var convertedPrefix; // convert string from JSON .eslintrc to regex
-
-            if (prefix === undefined) {
-                return;
-            }
 
             convertedPrefix = utils.convertPrefixToRegex(prefix);
 
@@ -55,3 +51,9 @@ module.exports = function(context) {
         }
     };
 };
+
+module.exports.schema = [
+    {
+        type: 'string'
+    }
+];

--- a/test/controller-name.js
+++ b/test/controller-name.js
@@ -19,13 +19,10 @@ eslintTester.run('controller-name', rule, {
         options: ['eslint']
     }, {
         code: 'app.controller("eslintController", function() {});',
-        options: [/^eslint/]
-    }, {
-        code: 'app.controller("eslintController", function() {});',
-        options: [undefined]
+        options: ['/^eslint/']
     }, {
         code: 'app.controller("EslintController", function() {});',
-        options: [/[A-Z].*Controller$/]
+        options: ['/[A-Z].*Controller$/']
     }, {
         code: 'app.controller("EslintController", function() {});',
         options: ['/[A-Z].*Controller$/']
@@ -49,17 +46,17 @@ eslintTester.run('controller-name', rule, {
         },
         {
             code: 'app.controller("Controller", function() {});',
-            options: [/^eslint/],
+            options: ['/^eslint/'],
             errors: [{message: 'The Controller controller should follow this pattern: /^eslint/'}]
         },
         {
             code: 'app.controller("customers", function() {});',
-            options: [/[A-Z].*Controller$/],
+            options: ['/[A-Z].*Controller$/'],
             errors: [{message: 'The customers controller should follow this pattern: /[A-Z].*Controller$/'}]
         },
         {
             code: 'app.controller("customersController", function() {});',
-            options: [/[A-Z].*Controller$/],
+            options: ['/[A-Z].*Controller$/'],
             errors: [{message: 'The customersController controller should follow this pattern: /[A-Z].*Controller$/'}]
         }, {
             code: 'app.controller("eslintController", function() {});',


### PR DESCRIPTION
Default configurations are no longer supported in `eslint@^2.0.0`.

I ran into some issues removing this.

I can fix the following pretty easily:
- Tests appear to be using non-primitive types. This is not supported in a JSON schema / ESLint configuration [JSON Schema primitive types](http://json-schema.org/latest/json-schema-core.html#anchor8)

I can work around this:
- Unlike a live run of ESLint, the rule tester does seem to use the `rulesConfig`.

I'm not sure what to do about this:
- `rulesConfig` is used to generate the defaults section in the readme. @tilmanpotthof I believe you created the scripts that generate this. Could you take a look at this? Should I just make all defaults turn to zeroes for this PR?

There are more rules having defaults. I'll remove these in upcoming commits in this PR.