### PR TITLE
Remove link to #defaults from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Since the 0.0.4 release, some rules defined in [John Papa's Guideline](https://g
 
 - [Usage with shareable config](#usage-with-shareable-config)
 - [Usage without shareable config](#usage-without-shareable-config)
-- [Defaults](#defaults)
 - [Rules](#rules)
 - [Need your help](#need-your-help)
 - [How to create a new rule](#how-to-create-a-new-rule)


### PR DESCRIPTION
I don't know why defaults config removed,
Please prepare a change log for those who are upgrading  from 0.15.0 to 1.0.0.