### PR TITLE
Fixed issue when names are composite numbers. The following example:

### DIFF
--- a/rules/file-name.js
+++ b/rules/file-name.js
@@ -67,7 +67,7 @@ module.exports = (function() {
             var nameSeparator = separators[nameStyle];
             if (nameSeparator) {
                 var replacement = '$1' + nameSeparator + '$2';
-                name = name.replace(/([a-z])([A-Z])/g, replacement).toLowerCase();
+                name = name.replace(/([a-z0-9])([A-Z])/g, replacement).toLowerCase();
             }
             return name;
         },


### PR DESCRIPTION
The following example:

```
/*eslint angular/file-name: [2,{"typeSeparator":"dot","nameStyle":"dash","ignoreTypeSuffix":true}]*/

//
// Before fix

// invalid with filename: yii2-message.directive.js
angular.directive('yii2Message', []);

// valid with filename: yii2message.directive.js
angular.directive('yii2Message', []);

//
// After fix

// valid with filename: yii2-message.directive.js
angular.directive('yii2Message', []);

// invalid with filename: yii2message.directive.js
angular.directive('yii2Message', []);

```