### PR TITLE
Fixed issue when names are composite numbers.

### DIFF
--- a/rules/file-name.js
+++ b/rules/file-name.js
@@ -67,7 +67,7 @@ module.exports = (function() {
             var nameSeparator = separators[nameStyle];
             if (nameSeparator) {
                 var replacement = '$1' + nameSeparator + '$2';
-                name = name.replace(/([a-z])([A-Z])/g, replacement).toLowerCase();
+                name = name.replace(/([a-z0-9])([A-Z])/g, replacement).toLowerCase();
             }
             return name;
         },

--- a/test/file-name.js
+++ b/test/file-name.js
@@ -152,6 +152,22 @@ eslintTester.run('file-name', rule, {
             typeSeparator: 'underscore',
             ignorePrefix: 'st'
         }]
+    }, {
+        // alphanumeric nameStyle dash and typeSeparator dash with service
+        filename: 'src/app/app2-utils-service.js',
+        code: 'app.factory("app2Utils", function() {});',
+        options: [{
+            typeSeparator: 'dash',
+            nameStyle: 'dash'
+        }]
+    }, {
+        // alphanumeric nameStyle underscore and typeSeparator dot with directive
+        filename: 'src/app/my2_tab.directive.js',
+        code: 'app.directive("my2Tab", function() {});',
+        options: [{
+            typeSeparator: 'dot',
+            nameStyle: 'underscore'
+        }]
     }].concat(commonFalsePositives),
     invalid: [{
         filename: 'src/app/filters.js',
@@ -208,5 +224,23 @@ eslintTester.run('file-name', rule, {
             ignorePrefix: 'xp'
         }],
         errors: [{message: 'Filename must be "asset.service.js"'}]
+    }, {
+        // alphanumeric nameStyle dash and typeSeparator dash with service
+        filename: 'src/app/app2utils-service.js',
+        code: 'app.factory("app2Utils", function() {});',
+        options: [{
+            typeSeparator: 'dash',
+            nameStyle: 'dash'
+        }],
+        errors: [{message: 'Filename must be "app2-utils-service.js"'}]
+    }, {
+        // alphanumeric nameStyle underscore and typeSeparator dot with directive
+        filename: 'src/app/my2tab.directive.js',
+        code: 'app.directive("my2Tab", function() {});',
+        options: [{
+            typeSeparator: 'dot',
+            nameStyle: 'underscore'
+        }],
+        errors: [{message: 'Filename must be "my2_tab.directive.js"'}]
     }]
 });


### PR DESCRIPTION
The following example:

```
/*eslint angular/file-name: [2,{"typeSeparator":"dot","nameStyle":"dash","ignoreTypeSuffix":true}]*/

//
// Before fix

// invalid with filename: yii2-message.directive.js
angular.directive('yii2Message', []);

// valid with filename: yii2message.directive.js
angular.directive('yii2Message', []);

//
// After fix

// valid with filename: yii2-message.directive.js
angular.directive('yii2Message', []);

// invalid with filename: yii2message.directive.js
angular.directive('yii2Message', []);

```