### PR TITLE
correct regexp for UpperCamelCase / Y123

### DIFF
--- a/rules/controller-name.js
+++ b/rules/controller-name.js
@@ -18,7 +18,7 @@ module.exports = function(context) {
     return {
 
         CallExpression: function(node) {
-            var prefix = context.options[0] || '/[A-Z].*Controller$/';
+            var prefix = context.options[0] || '/^[A-Z][a-zA-Z0-9]*Controller$/';
             var convertedPrefix; // convert string from JSON .eslintrc to regex
 
             convertedPrefix = utils.convertPrefixToRegex(prefix);


### PR DESCRIPTION
closes #359

the current version misses the `^` making sure the FIRST letter is upper case, not just any letter before the string `Controller`. Also, using `.*` in between, allows for non-UpperCamelCase namings, including special characters.