### PR TITLE
di-order.md: Corrected the description

### DIFF
--- a/docs/di-order.md
+++ b/docs/di-order.md
@@ -3,7 +3,7 @@
 # di-order - require DI parameters to be sorted alphabetically
 
 Injected dependencies should be sorted alphabetically.
-If the second parameter is set to false, values which start and end with an underscore those underscores are stripped.
+If the second parameter is set to `true`, values which start and end with an underscore those underscores are stripped.
 This means for example that `_$httpBackend_` goes before `_$http_`.
 
 ## Examples


### PR DESCRIPTION
According to the rule's source and the given examples, the parameter has to be set to `true` to strip underscores while checking.


*corresponding rule-code:*

```JavaScript
            var stripUnderscores = context.options[0] !== false;
            // [...]
            if (stripUnderscores) {
                formattedArg = formattedArg.replace(/^_(.+)_$/, '$1');
            }
```