### PR TITLE
Fixes a crash on prefer-component

### DIFF
--- a/rules/prefer-component.js
+++ b/rules/prefer-component.js
@@ -51,7 +51,7 @@ module.exports = angularRule(function(context) {
         },
         Property: function(node) {
             if (node.key.name === 'restrict') {
-                if (node.value.raw.indexOf('C') < 0 && node.value.raw.indexOf('A') < 0) {
+                if (node.value.raw && node.value.raw.indexOf('C') < 0 && node.value.raw.indexOf('A') < 0) {
                     return;
                 }
             } else if (allowedProperties.indexOf(node.key.name) < 0) {

--- a/test/prefer-component.js
+++ b/test/prefer-component.js
@@ -26,6 +26,7 @@ eslintTester.run('prefer-component', rule, {
         'angular.module("").directive("", function() {return {restrict: "A"}})',
         'angular.module("").directive("", function() {return {restrict: "C"}})',
         'angular.module("").directive("", function() {return {restrict: "AE"}})',
+        'angular.module("").directive("", function() {return {restrict: aVariable}})',
         'angular.module("").directive("", function() { function x() { return {link: function(){}} }; x(); return {}; })',
         'angular.module("").directive("", function() {return {link:function(){}}})',
         'angular.module("").directive("", function() { var def = {link: function(){}}; return def; })',


### PR DESCRIPTION
... when the value of "restrict" is not a string literal.

```js
angular.module('myModule').directive('myDirective', 
function() {
    return {
        restrict: foo, // This is usually a string literal, e.g. "EA"
        ...
    };
}]);
```


The bug was discovered while checking this code snippet.
http://stackoverflow.com/a/29010910/437