### PR TITLE
Change `service-name` rule to apply only `angular.Module#service` - (WIP)

### DIFF
--- a/docs/constant-name.md
+++ b/docs/constant-name.md
@@ -1,0 +1,59 @@
+<!-- WARNING: Generated documentation. Edit docs and examples in the rule and examples file ('rules/constant-name.js', 'examples/constant-name.js'). -->
+
+# constant-name - require and specify a prefix for all constant names
+
+All your constants should have a name starting with the parameter you can define in your config object.
+The second parameter can be a Regexp wrapped in quotes.
+You can not prefix your constants by "$" (reserved keyword for AngularJS services) ("constant-name":  [2, "ng"])
+*
+
+**Styleguide Reference**
+
+* [y125 by johnpapa - Naming - Factory and Service Names](https://github.com/johnpapa/angular-styleguide/blob/master/a1/README.md#style-y125)
+
+## Examples
+
+The following patterns are **not** considered problems when configured `"prefix"`:
+
+    /*eslint angular/constant-name: [2,"prefix"]*/
+
+    // valid
+    angular.module('myModule').constant('prefixConstant', function () {
+        // ...
+    });
+
+The following patterns are considered problems when configured `"/^xyz/"`:
+
+    /*eslint angular/constant-name: [2,"/^xyz/"]*/
+
+    // invalid
+    angular.module('myModule').constant('otherConstant', function () {
+        // ...
+    }); // error: The otherConstant constant should follow this pattern: /^xyz/
+
+The following patterns are **not** considered problems when configured `"/^xyz/"`:
+
+    /*eslint angular/constant-name: [2,"/^xyz/"]*/
+
+    // valid
+    angular.module('myModule').constant('xyzConstant', function () {
+        // ...
+    });
+
+The following patterns are considered problems when configured `"xyz"`:
+
+    /*eslint angular/constant-name: [2,"xyz"]*/
+
+    // invalid
+    angular.module('myModule').constant('myConstant', function () {
+        // ...
+    }); // error: The myConstant constant should be prefixed by xyz
+
+## Version
+
+This rule was introduced in eslint-plugin-angular 1.4.1
+
+## Links
+
+* [Rule source](../rules/constant-name.js)
+* [Example source](../examples/constant-name.js)

--- a/docs/factory-name.md
+++ b/docs/factory-name.md
@@ -1,0 +1,59 @@
+<!-- WARNING: Generated documentation. Edit docs and examples in the rule and examples file ('rules/factory-name.js', 'examples/factory-name.js'). -->
+
+# factory-name - require and specify a prefix for all factory names
+
+All your factories should have a name starting with the parameter you can define in your config object.
+The second parameter can be a Regexp wrapped in quotes.
+You can not prefix your factories by "$" (reserved keyword for AngularJS services) ("factory-name":  [2, "ng"])
+*
+
+**Styleguide Reference**
+
+* [y125 by johnpapa - Naming - Factory and Service Names](https://github.com/johnpapa/angular-styleguide/blob/master/a1/README.md#style-y125)
+
+## Examples
+
+The following patterns are **not** considered problems when configured `"prefix"`:
+
+    /*eslint angular/factory-name: [2,"prefix"]*/
+
+    // valid
+    angular.module('myModule').factory('prefixFactory', function () {
+        // ...
+    });
+
+The following patterns are considered problems when configured `"/^xyz/"`:
+
+    /*eslint angular/factory-name: [2,"/^xyz/"]*/
+
+    // invalid
+    angular.module('myModule').factory('otherFactory', function () {
+        // ...
+    }); // error: The otherFactory factory should follow this pattern: /^xyz/
+
+The following patterns are **not** considered problems when configured `"/^xyz/"`:
+
+    /*eslint angular/factory-name: [2,"/^xyz/"]*/
+
+    // valid
+    angular.module('myModule').factory('xyzFactory', function () {
+        // ...
+    });
+
+The following patterns are considered problems when configured `"xyz"`:
+
+    /*eslint angular/factory-name: [2,"xyz"]*/
+
+    // invalid
+    angular.module('myModule').factory('myFactory', function () {
+        // ...
+    }); // error: The myFactory factory should be prefixed by xyz
+
+## Version
+
+This rule was introduced in eslint-plugin-angular 1.4.1
+
+## Links
+
+* [Rule source](../rules/factory-name.js)
+* [Example source](../examples/factory-name.js)

--- a/docs/provider-name.md
+++ b/docs/provider-name.md
@@ -1,0 +1,59 @@
+<!-- WARNING: Generated documentation. Edit docs and examples in the rule and examples file ('rules/provider-name.js', 'examples/provider-name.js'). -->
+
+# provider-name - require and specify a prefix for all provider names
+
+All your providers should have a name starting with the parameter you can define in your config object.
+The second parameter can be a Regexp wrapped in quotes.
+You can not prefix your providers by "$" (reserved keyword for AngularJS services) ("provider-name":  [2, "ng"])
+*
+
+**Styleguide Reference**
+
+* [y125 by johnpapa - Naming - Factory and Service Names](https://github.com/johnpapa/angular-styleguide/blob/master/a1/README.md#style-y125)
+
+## Examples
+
+The following patterns are **not** considered problems when configured `"prefix"`:
+
+    /*eslint angular/provider-name: [2,"prefix"]*/
+
+    // valid
+    angular.module('myModule').provider('prefixProvider', function () {
+        // ...
+    });
+
+The following patterns are considered problems when configured `"/^xyz/"`:
+
+    /*eslint angular/provider-name: [2,"/^xyz/"]*/
+
+    // invalid
+    angular.module('myModule').provider('otherProvider', function () {
+        // ...
+    }); // error: The otherProvider provider should follow this pattern: /^xyz/
+
+The following patterns are **not** considered problems when configured `"/^xyz/"`:
+
+    /*eslint angular/provider-name: [2,"/^xyz/"]*/
+
+    // valid
+    angular.module('myModule').provider('xyzProvider', function () {
+        // ...
+    });
+
+The following patterns are considered problems when configured `"xyz"`:
+
+    /*eslint angular/provider-name: [2,"xyz"]*/
+
+    // invalid
+    angular.module('myModule').provider('myProvider', function () {
+        // ...
+    }); // error: The myProvider provider should be prefixed by xyz
+
+## Version
+
+This rule was introduced in eslint-plugin-angular 1.4.1
+
+## Links
+
+* [Rule source](../rules/provider-name.js)
+* [Example source](../examples/provider-name.js)

--- a/docs/service-name.md
+++ b/docs/service-name.md
@@ -4,7 +4,10 @@
 
 All your services should have a name starting with the parameter you can define in your config object.
 The second parameter can be a Regexp wrapped in quotes.
-You can not prefix your services by "$" (reserved keyword for AngularJS services) ("service-name":  [2, "ng"])
+Please note, that the rule will be changed in future version to only support `angular.Module#service()`.
+If you want the new behavior use the flag `{oldBehavior: false}`.
+For factories, providers, constants and values, you can should use their rules. 
+You can not prefix your services by "$" (reserved keyword for AngularJS services) ("service-name":  [2, "ng", {oldBehavior: false}])
 *
 
 **Styleguide Reference**
@@ -15,37 +18,37 @@ You can not prefix your services by "$" (reserved keyword for AngularJS services
 
 The following patterns are **not** considered problems when configured `"prefix"`:
 
-    /*eslint angular/service-name: [2,"prefix"]*/
+    /*eslint angular/service-name: [2,"prefix",{oldBehavior: false}]*/
 
     // valid
-    angular.module('myModule').factory('prefixService', function () {
+    angular.module('myModule').service('prefixService', function () {
         // ...
     });
 
 The following patterns are considered problems when configured `"/^xyz/"`:
 
-    /*eslint angular/service-name: [2,"/^xyz/"]*/
+    /*eslint angular/service-name: [2,"/^xyz/",{oldBehavior: false}]*/
 
     // invalid
-    angular.module('myModule').factory('otherService', function () {
+    angular.module('myModule').service('otherService', function () {
         // ...
     }); // error: The otherService service should follow this pattern: /^xyz/
 
 The following patterns are **not** considered problems when configured `"/^xyz/"`:
 
-    /*eslint angular/service-name: [2,"/^xyz/"]*/
+    /*eslint angular/service-name: [2,"/^xyz/",{oldBehavior: false}]*/
 
     // valid
-    angular.module('myModule').factory('xyzService', function () {
+    angular.module('myModule').service('xyzService', function () {
         // ...
     });
 
 The following patterns are considered problems when configured `"xyz"`:
 
-    /*eslint angular/service-name: [2,"xyz"]*/
+    /*eslint angular/service-name: [2,"xyz",{oldBehavior: false}]*/
 
     // invalid
-    angular.module('myModule').factory('myService', function () {
+    angular.module('myModule').service('myService', function () {
         // ...
     }); // error: The myService service should be prefixed by xyz
 

--- a/docs/value-name.md
+++ b/docs/value-name.md
@@ -1,0 +1,59 @@
+<!-- WARNING: Generated documentation. Edit docs and examples in the rule and examples file ('rules/value-name.js', 'examples/value-name.js'). -->
+
+# value-name - require and specify a prefix for all value names
+
+All your values should have a name starting with the parameter you can define in your config object.
+The second parameter can be a Regexp wrapped in quotes.
+You can not prefix your values by "$" (reserved keyword for AngularJS services) ("value-name":  [2, "ng"])
+*
+
+**Styleguide Reference**
+
+* [y125 by johnpapa - Naming - Factory and Service Names](https://github.com/johnpapa/angular-styleguide/blob/master/a1/README.md#style-y125)
+
+## Examples
+
+The following patterns are **not** considered problems when configured `"prefix"`:
+
+    /*eslint angular/value-name: [2,"prefix"]*/
+
+    // valid
+    angular.module('myModule').value('prefixValue', function () {
+        // ...
+    });
+
+The following patterns are considered problems when configured `"/^xyz/"`:
+
+    /*eslint angular/value-name: [2,"/^xyz/"]*/
+
+    // invalid
+    angular.module('myModule').value('otherValue', function () {
+        // ...
+    }); // error: The otherValue value should follow this pattern: /^xyz/
+
+The following patterns are **not** considered problems when configured `"/^xyz/"`:
+
+    /*eslint angular/value-name: [2,"/^xyz/"]*/
+
+    // valid
+    angular.module('myModule').value('xyzValue', function () {
+        // ...
+    });
+
+The following patterns are considered problems when configured `"xyz"`:
+
+    /*eslint angular/value-name: [2,"xyz"]*/
+
+    // invalid
+    angular.module('myModule').value('myValue', function () {
+        // ...
+    }); // error: The myValue value should be prefixed by xyz
+
+## Version
+
+This rule was introduced in eslint-plugin-angular 1.4.1
+
+## Links
+
+* [Rule source](../rules/value-name.js)
+* [Example source](../examples/value-name.js)

--- a/examples/constant-name.js
+++ b/examples/constant-name.js
@@ -1,0 +1,19 @@
+// example - valid: true, options: ["prefix"]
+angular.module('myModule').constant('prefixConstant', function () {
+    // ...
+});
+
+// example - valid: true, options: ["/^xyz/"]
+angular.module('myModule').constant('xyzConstant', function () {
+    // ...
+});
+
+// example - valid: false, options: ["xyz"], errorMessage: "The myConstant constant should be prefixed by xyz"
+angular.module('myModule').constant('myConstant', function () {
+    // ...
+});
+
+// example - valid: false, options: ["/^xyz/"], errorMessage: "The otherConstant constant should follow this pattern\: /^xyz/"
+angular.module('myModule').constant('otherConstant', function () {
+    // ...
+});

--- a/examples/factory-name.js
+++ b/examples/factory-name.js
@@ -1,0 +1,19 @@
+// example - valid: true, options: ["prefix"]
+angular.module('myModule').factory('prefixFactory', function () {
+    // ...
+});
+
+// example - valid: true, options: ["/^xyz/"]
+angular.module('myModule').factory('xyzFactory', function () {
+    // ...
+});
+
+// example - valid: false, options: ["xyz"], errorMessage: "The myFactory factory should be prefixed by xyz"
+angular.module('myModule').factory('myFactory', function () {
+    // ...
+});
+
+// example - valid: false, options: ["/^xyz/"], errorMessage: "The otherFactory factory should follow this pattern\: /^xyz/"
+angular.module('myModule').factory('otherFactory', function () {
+    // ...
+});

--- a/examples/provider-name.js
+++ b/examples/provider-name.js
@@ -1,0 +1,19 @@
+// example - valid: true, options: ["prefix"]
+angular.module('myModule').provider('prefixProvider', function () {
+    // ...
+});
+
+// example - valid: true, options: ["/^xyz/"]
+angular.module('myModule').provider('xyzProvider', function () {
+    // ...
+});
+
+// example - valid: false, options: ["xyz"], errorMessage: "The myProvider provider should be prefixed by xyz"
+angular.module('myModule').provider('myProvider', function () {
+    // ...
+});
+
+// example - valid: false, options: ["/^xyz/"], errorMessage: "The otherProvider provider should follow this pattern\: /^xyz/"
+angular.module('myModule').provider('otherProvider', function () {
+    // ...
+});

--- a/examples/service-name.js
+++ b/examples/service-name.js
@@ -1,20 +1,20 @@
-// example - valid: true, options: ["prefix"]
-angular.module('myModule').factory('prefixService', function () {
+// example - valid: true, options: ["prefix", {oldBehavior: false}]
+angular.module('myModule').service('prefixService', function () {
     // ...
 });
 
-// example - valid: true, options: ["/^xyz/"]
-angular.module('myModule').factory('xyzService', function () {
+// example - valid: true, options: ["/^xyz/", {oldBehavior: false}]
+angular.module('myModule').service('xyzService', function () {
     // ...
 });
 
-// example - valid: false, options: ["xyz"], errorMessage: "The myService service should be prefixed by xyz"
-angular.module('myModule').factory('myService', function () {
+// example - valid: false, options: ["xyz", {oldBehavior: false}], errorMessage: "The myService service should be prefixed by xyz"
+angular.module('myModule').service('myService', function () {
     // ...
 });
 
-// example - valid: false, options: ["/^xyz/"], errorMessage: "The otherService service should follow this pattern\: /^xyz/"
-angular.module('myModule').factory('otherService', function () {
+// example - valid: false, options: ["/^xyz/", {oldBehavior: false}], errorMessage: "The otherService service should follow this pattern\: /^xyz/"
+angular.module('myModule').service('otherService', function () {
     // ...
 });
 

--- a/examples/value-name.js
+++ b/examples/value-name.js
@@ -1,0 +1,19 @@
+// example - valid: true, options: ["prefix"]
+angular.module('myModule').value('prefixValue', function () {
+    // ...
+});
+
+// example - valid: true, options: ["/^xyz/"]
+angular.module('myModule').value('xyzValue', function () {
+    // ...
+});
+
+// example - valid: false, options: ["xyz"], errorMessage: "The myValue value should be prefixed by xyz"
+angular.module('myModule').value('myValue', function () {
+    // ...
+});
+
+// example - valid: false, options: ["/^xyz/"], errorMessage: "The otherValue value should follow this pattern\: /^xyz/"
+angular.module('myModule').value('otherValue', function () {
+    // ...
+});

--- a/rules/constant-name.js
+++ b/rules/constant-name.js
@@ -1,0 +1,56 @@
+/**
+ * require and specify a prefix for all constant names
+ *
+ * All your constants should have a name starting with the parameter you can define in your config object.
+ * The second parameter can be a Regexp wrapped in quotes.
+ * You can not prefix your constants by "$" (reserved keyword for AngularJS services) ("constant-name":  [2, "ng"])
+ **
+ * @styleguideReference {johnpapa} `y125` Naming - Factory and Service Names
+ * @version 0.1.0
+ * @category naming
+ */
+'use strict';
+
+
+var utils = require('./utils/utils');
+
+
+module.exports = function(context) {
+    return {
+
+        CallExpression: function(node) {
+            var prefix = context.options[0];
+            var convertedPrefix; // convert string from JSON .eslintrc to regex
+            var isConstant;
+
+            if (prefix === undefined) {
+                return;
+            }
+
+            convertedPrefix = utils.convertPrefixToRegex(prefix);
+            isConstant = utils.isAngularConstantDeclaration(node);
+
+            if (isConstant) {
+                var name = node.arguments[0].value;
+
+                if (name !== undefined && name.indexOf('$') === 0) {
+                    context.report(node, 'The {{constant}} constant should not start with "$". This is reserved for AngularJS services', {
+                        constant: name
+                    });
+                } else if (name !== undefined && !convertedPrefix.test(name)) {
+                    if (typeof prefix === 'string' && !utils.isStringRegexp(prefix)) {
+                        context.report(node, 'The {{constant}} constant should be prefixed by {{prefix}}', {
+                            constant: name,
+                            prefix: prefix
+                        });
+                    } else {
+                        context.report(node, 'The {{constant}} constant should follow this pattern: {{prefix}}', {
+                            constant: name,
+                            prefix: prefix.toString()
+                        });
+                    }
+                }
+            }
+        }
+    };
+};

--- a/rules/factory-name.js
+++ b/rules/factory-name.js
@@ -1,0 +1,56 @@
+/**
+ * require and specify a prefix for all factory names
+ *
+ * All your factorys should have a name starting with the parameter you can define in your config object.
+ * The second parameter can be a Regexp wrapped in quotes.
+ * You can not prefix your factorys by "$" (reserved keyword for AngularJS services) ("factory-name":  [2, "ng"])
+ **
+ * @styleguideReference {johnpapa} `y125` Naming - Factory and Service Names
+ * @version 0.1.0
+ * @category naming
+ */
+'use strict';
+
+
+var utils = require('./utils/utils');
+
+
+module.exports = function(context) {
+    return {
+
+        CallExpression: function(node) {
+            var prefix = context.options[0];
+            var convertedPrefix; // convert string from JSON .eslintrc to regex
+            var isFactory;
+
+            if (prefix === undefined) {
+                return;
+            }
+
+            convertedPrefix = utils.convertPrefixToRegex(prefix);
+            isFactory = utils.isAngularFactoryDeclaration(node);
+
+            if (isFactory) {
+                var name = node.arguments[0].value;
+
+                if (name !== undefined && name.indexOf('$') === 0) {
+                    context.report(node, 'The {{factory}} factory should not start with "$". This is reserved for AngularJS services', {
+                        factory: name
+                    });
+                } else if (name !== undefined && !convertedPrefix.test(name)) {
+                    if (typeof prefix === 'string' && !utils.isStringRegexp(prefix)) {
+                        context.report(node, 'The {{factory}} factory should be prefixed by {{prefix}}', {
+                            factory: name,
+                            prefix: prefix
+                        });
+                    } else {
+                        context.report(node, 'The {{factory}} factory should follow this pattern: {{prefix}}', {
+                            factory: name,
+                            prefix: prefix.toString()
+                        });
+                    }
+                }
+            }
+        }
+    };
+};

--- a/rules/module-getter.js
+++ b/rules/module-getter.js
@@ -19,6 +19,9 @@ module.exports = function(context) {
             if ((utils.isAngularControllerDeclaration(node.expression) ||
                     utils.isAngularFilterDeclaration(node.expression) ||
                     utils.isAngularServiceDeclaration(node.expression) ||
+                    utils.isAngularFactoryDeclaration(node.expression) ||
+                    utils.isAngularConstantDeclaration(node.expression) ||
+                    utils.isAngularValueDeclaration(node.expression) ||
                     utils.isAngularDirectiveDeclaration(node.expression) ||
                     utils.isAngularRunSection(node.expression) ||
                     utils.isAngularConfigSection(node.expression)) &&

--- a/rules/provider-name.js
+++ b/rules/provider-name.js
@@ -1,0 +1,56 @@
+/**
+ * require and specify a prefix for all provider names
+ *
+ * All your providers should have a name starting with the parameter you can define in your config object.
+ * The second parameter can be a Regexp wrapped in quotes.
+ * You can not prefix your providers by "$" (reserved keyword for AngularJS services) ("provider-name":  [2, "ng"])
+ **
+ * @styleguideReference {johnpapa} `y125` Naming - Factory and Service Names
+ * @version 0.1.0
+ * @category naming
+ */
+'use strict';
+
+
+var utils = require('./utils/utils');
+
+
+module.exports = function(context) {
+    return {
+
+        CallExpression: function(node) {
+            var prefix = context.options[0];
+            var convertedPrefix; // convert string from JSON .eslintrc to regex
+            var isProvider;
+
+            if (prefix === undefined) {
+                return;
+            }
+
+            convertedPrefix = utils.convertPrefixToRegex(prefix);
+            isProvider = utils.isAngularProviderDeclaration(node);
+
+            if (isProvider) {
+                var name = node.arguments[0].value;
+
+                if (name !== undefined && name.indexOf('$') === 0) {
+                    context.report(node, 'The {{provider}} provider should not start with "$". This is reserved for AngularJS services', {
+                        provider: name
+                    });
+                } else if (name !== undefined && !convertedPrefix.test(name)) {
+                    if (typeof prefix === 'string' && !utils.isStringRegexp(prefix)) {
+                        context.report(node, 'The {{provider}} provider should be prefixed by {{prefix}}', {
+                            provider: name,
+                            prefix: prefix
+                        });
+                    } else {
+                        context.report(node, 'The {{provider}} provider should follow this pattern: {{prefix}}', {
+                            provider: name,
+                            prefix: prefix.toString()
+                        });
+                    }
+                }
+            }
+        }
+    };
+};

--- a/rules/service-name.js
+++ b/rules/service-name.js
@@ -60,6 +60,9 @@ module.exports = function(context) {
 
             if (config.oldBehavior) {
                 isService = utils.isAngularServiceDeclarationDeprecated(node);
+                // Warning that the API is deprecated
+                // eslint-disable-next-line
+                console.warn('The rule `angular/service-name` will be split up to different rules in the next version. Please read the docs for more information');
             } else {
                 isService = utils.isAngularServiceDeclaration(node);
             }

--- a/rules/utils/utils.js
+++ b/rules/utils/utils.js
@@ -53,7 +53,8 @@ module.exports = {
     isUIRouterStateDefinition: isUIRouterStateDefinition,
     findIdentiferInScope: findIdentiferInScope,
     getControllerDefinition: getControllerDefinition,
-    isAngularServiceImport: isAngularServiceImport
+    isAngularServiceImport: isAngularServiceImport,
+    getToStringTagType: getToStringTagType
 };
 
 
@@ -536,4 +537,15 @@ function getControllerDefinition(context, node) {
 function isAngularServiceImport(parameterName, serviceName) {
     var r = new RegExp('^\_?' + serviceName.replace(/[!@#$%^&*()+=\-[\]\\';,./{}|":<>?~_]/g, '\\$&') + '\_?$', 'i');
     return r.test(parameterName);
+}
+
+/**
+ * Return the value of the given param that retrieved by Object#toString()
+ *
+ * @param {*} obj
+ * @return {string}
+ */
+function getToStringTagType(obj) {
+    return Object.prototype.toString.apply(obj)
+        .match(/^\[object\s(.+)]$/)[1];
 }

--- a/rules/utils/utils.js
+++ b/rules/utils/utils.js
@@ -44,7 +44,12 @@ module.exports = {
     isAngularControllerDeclaration: isAngularControllerDeclaration,
     isAngularFilterDeclaration: isAngularFilterDeclaration,
     isAngularDirectiveDeclaration: isAngularDirectiveDeclaration,
+    isAngularServiceDeclarationDeprecated: isAngularServiceDeclarationDeprecated,
     isAngularServiceDeclaration: isAngularServiceDeclaration,
+    isAngularProviderDeclaration: isAngularProviderDeclaration,
+    isAngularFactoryDeclaration: isAngularFactoryDeclaration,
+    isAngularConstantDeclaration: isAngularConstantDeclaration,
+    isAngularValueDeclaration: isAngularValueDeclaration,
     isAngularModuleDeclaration: isAngularModuleDeclaration,
     isAngularModuleGetter: isAngularModuleGetter,
     isAngularRunSection: isAngularRunSection,
@@ -335,7 +340,7 @@ function isAngularDirectiveDeclaration(node) {
  * @param {Object} node The CallExpression node to check.
  * @returns {boolean} Whether or not the node defines an Angular controller.
  */
-function isAngularServiceDeclaration(node) {
+function isAngularServiceDeclarationDeprecated(node) {
     return isAngularComponent(node) &&
         isMemberExpression(node.callee) &&
         node.callee.object.name !== '$provide' &&
@@ -344,6 +349,57 @@ function isAngularServiceDeclaration(node) {
          node.callee.property.name === 'factory' ||
          node.callee.property.name === 'constant' ||
          node.callee.property.name === 'value');
+}
+
+/*
+ * @param {Object}
+ * @returns {boolean}
+ */
+function isAngularServiceDeclaration(node) {
+    return isAngularComponent(node) &&
+        isMemberExpression(node.callee) &&
+        node.callee.object.name !== '$provide' &&
+        node.callee.property.name === 'service';
+}
+
+/*
+ * @param {Object}
+ * @returns {boolean}
+ */
+function isAngularProviderDeclaration(node) {
+    return isAngularComponent(node) &&
+        isMemberExpression(node.callee) &&
+        node.callee.object.name !== '$provide' &&
+        node.callee.property.name === 'provider';
+}
+
+/*
+ * @param {Object}
+ * @returns {boolean}
+ */
+function isAngularFactoryDeclaration(node) {
+    return isAngularComponent(node) &&
+        isMemberExpression(node.callee) &&
+        node.callee.object.name !== '$provide' &&
+        node.callee.property.name === 'factory';
+}
+
+/*
+ * @param {Object}
+ * @returns {boolean}
+ */
+function isAngularConstantDeclaration(node) {
+    return isAngularComponent(node) &&
+        isMemberExpression(node.callee) &&
+        node.callee.object.name !== '$provide' &&
+        node.callee.property.name === 'constant';
+}
+
+function isAngularValueDeclaration(node) {
+    return isAngularComponent(node) &&
+        isMemberExpression(node.callee) &&
+        node.callee.object.name !== '$provide' &&
+        node.callee.property.name === 'value';
 }
 
 /**

--- a/rules/value-name.js
+++ b/rules/value-name.js
@@ -1,0 +1,56 @@
+/**
+ * require and specify a prefix for all value names
+ *
+ * All your values should have a name starting with the parameter you can define in your config object.
+ * The second parameter can be a Regexp wrapped in quotes.
+ * You can not prefix your values by "$" (reserved keyword for AngularJS services) ("value-name":  [2, "ng"])
+ **
+ * @styleguideReference {johnpapa} `y125` Naming - Factory and Service Names
+ * @version 0.1.0
+ * @category naming
+ */
+'use strict';
+
+
+var utils = require('./utils/utils');
+
+
+module.exports = function(context) {
+    return {
+
+        CallExpression: function(node) {
+            var prefix = context.options[0];
+            var convertedPrefix; // convert string from JSON .eslintrc to regex
+            var isValue;
+
+            if (prefix === undefined) {
+                return;
+            }
+
+            convertedPrefix = utils.convertPrefixToRegex(prefix);
+            isValue = utils.isAngularValueDeclaration(node);
+
+            if (isValue) {
+                var name = node.arguments[0].value;
+
+                if (name !== undefined && name.indexOf('$') === 0) {
+                    context.report(node, 'The {{value}} value should not start with "$". This is reserved for AngularJS services', {
+                        value: name
+                    });
+                } else if (name !== undefined && !convertedPrefix.test(name)) {
+                    if (typeof prefix === 'string' && !utils.isStringRegexp(prefix)) {
+                        context.report(node, 'The {{value}} value should be prefixed by {{prefix}}', {
+                            value: name,
+                            prefix: prefix
+                        });
+                    } else {
+                        context.report(node, 'The {{value}} value should follow this pattern: {{prefix}}', {
+                            value: name,
+                            prefix: prefix.toString()
+                        });
+                    }
+                }
+            }
+        }
+    };
+};

--- a/test/constant-name.js
+++ b/test/constant-name.js
@@ -1,0 +1,63 @@
+'use strict';
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+var rule = require('../rules/constant-name');
+var RuleTester = require('eslint').RuleTester;
+var commonFalsePositives = require('./utils/commonFalsePositives');
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+var eslintTester = new RuleTester();
+var valid = [];
+var invalid = [];
+
+
+/**
+ * New Behaviour
+ */
+
+valid.push({
+    code: 'app.constant("eslintConstant", function() {});',
+    options: ['eslint']
+}, {
+    code: 'app.constant("eslintConstant", function() {});',
+    options: [/^eslint/]
+}, {
+    code: 'app.constant("eslintConstant", function() {});',
+    options: [undefined]
+}, {
+    code: 'app.constant("eslintConstant", function() {});',
+    options: ['/^eslint/']
+});
+
+invalid.push({
+    code: 'app.constant("Constant", function() {});',
+    options: ['eslint'],
+    errors: [{message: 'The Constant constant should be prefixed by eslint'}]
+}, {
+    code: 'app.constant("esLintConstant", function() {});',
+    options: ['eslint'],
+    errors: [{message: 'The esLintConstant constant should be prefixed by eslint'}]
+}, {
+    code: 'app.constant("Constant", function() {});',
+    options: [/^eslint/],
+    errors: [{message: 'The Constant constant should follow this pattern: /^eslint/'}]
+}, {
+    code: 'app.constant("Constant", function() {});',
+    options: ['/^eslint/'],
+    errors: [{message: 'The Constant constant should follow this pattern: /^eslint/'}]
+}, {
+    code: 'app.constant("$Constant", function() {});',
+    options: [/^eslint/],
+    errors: [{message: 'The $Constant constant should not start with "$". This is reserved for AngularJS services'}]
+});
+
+eslintTester.run('constant-name', rule, {
+    valid: valid.concat(commonFalsePositives),
+    invalid: invalid
+});

--- a/test/factory-name.js
+++ b/test/factory-name.js
@@ -1,0 +1,63 @@
+'use strict';
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+var rule = require('../rules/factory-name');
+var RuleTester = require('eslint').RuleTester;
+var commonFalsePositives = require('./utils/commonFalsePositives');
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+var eslintTester = new RuleTester();
+var valid = [];
+var invalid = [];
+
+
+/**
+ * New Behaviour
+ */
+
+valid.push({
+    code: 'app.factory("eslintFactory", function() {});',
+    options: ['eslint']
+}, {
+    code: 'app.factory("eslintFactory", function() {});',
+    options: [/^eslint/]
+}, {
+    code: 'app.factory("eslintFactory", function() {});',
+    options: [undefined]
+}, {
+    code: 'app.factory("eslintFactory", function() {});',
+    options: ['/^eslint/']
+});
+
+invalid.push({
+    code: 'app.factory("Factory", function() {});',
+    options: ['eslint'],
+    errors: [{message: 'The Factory factory should be prefixed by eslint'}]
+}, {
+    code: 'app.factory("esLintFactory", function() {});',
+    options: ['eslint'],
+    errors: [{message: 'The esLintFactory factory should be prefixed by eslint'}]
+}, {
+    code: 'app.factory("Factory", function() {});',
+    options: [/^eslint/],
+    errors: [{message: 'The Factory factory should follow this pattern: /^eslint/'}]
+}, {
+    code: 'app.factory("Factory", function() {});',
+    options: ['/^eslint/'],
+    errors: [{message: 'The Factory factory should follow this pattern: /^eslint/'}]
+}, {
+    code: 'app.factory("$Factory", function() {});',
+    options: [/^eslint/],
+    errors: [{message: 'The $Factory factory should not start with "$". This is reserved for AngularJS services'}]
+});
+
+eslintTester.run('factory-name', rule, {
+    valid: valid.concat(commonFalsePositives),
+    invalid: invalid
+});

--- a/test/provider-name.js
+++ b/test/provider-name.js
@@ -1,0 +1,63 @@
+'use strict';
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+var rule = require('../rules/provider-name');
+var RuleTester = require('eslint').RuleTester;
+var commonFalsePositives = require('./utils/commonFalsePositives');
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+var eslintTester = new RuleTester();
+var valid = [];
+var invalid = [];
+
+
+/**
+ * New Behaviour
+ */
+
+valid.push({
+    code: 'app.provider("eslintProvider", function() {});',
+    options: ['eslint']
+}, {
+    code: 'app.provider("eslintProvider", function() {});',
+    options: [/^eslint/]
+}, {
+    code: 'app.provider("eslintProvider", function() {});',
+    options: [undefined]
+}, {
+    code: 'app.provider("eslintProvider", function() {});',
+    options: ['/^eslint/']
+});
+
+invalid.push({
+    code: 'app.provider("Provider", function() {});',
+    options: ['eslint'],
+    errors: [{message: 'The Provider provider should be prefixed by eslint'}]
+}, {
+    code: 'app.provider("esLintProvider", function() {});',
+    options: ['eslint'],
+    errors: [{message: 'The esLintProvider provider should be prefixed by eslint'}]
+}, {
+    code: 'app.provider("Provider", function() {});',
+    options: [/^eslint/],
+    errors: [{message: 'The Provider provider should follow this pattern: /^eslint/'}]
+}, {
+    code: 'app.provider("Provider", function() {});',
+    options: ['/^eslint/'],
+    errors: [{message: 'The Provider provider should follow this pattern: /^eslint/'}]
+}, {
+    code: 'app.provider("$Provider", function() {});',
+    options: [/^eslint/],
+    errors: [{message: 'The $Provider provider should not start with "$". This is reserved for AngularJS services'}]
+});
+
+eslintTester.run('provider-name', rule, {
+    valid: valid.concat(commonFalsePositives),
+    invalid: invalid
+});

--- a/test/service-name.js
+++ b/test/service-name.js
@@ -15,6 +15,65 @@ var commonFalsePositives = require('./utils/commonFalsePositives');
 var eslintTester = new RuleTester();
 var valid = [];
 var invalid = [];
+
+
+/**
+ * New Behaviour
+ */
+
+valid.push({
+    code: 'app.service("eslintService", function() {});',
+    options: ['eslint', {oldBehavior: false}]
+}, {
+    code: 'app.service("eslintService", function() {});',
+    options: [/^eslint/, {oldBehavior: false}]
+}, {
+    code: 'app.service("eslintService", function() {});',
+    options: [undefined, {oldBehavior: false}]
+}, {
+    code: 'app.service("eslintService", function() {});',
+    options: ['/^eslint/', {oldBehavior: false}]
+}, {
+    code: 'app.factory("$Service", function() {});',
+    options: [/^eslint/, {oldBehavior: false}]
+}, {
+    code: 'app.constant("$Service", function() {});',
+    options: [/^eslint/, {oldBehavior: false}]
+}, {
+    code: 'app.value("$Service", function() {});',
+    options: [/^eslint/, {oldBehavior: false}]
+}, {
+    code: 'app.provider("$Service", function() {});',
+    options: [/^eslint/, {oldBehavior: false}]
+});
+
+invalid.push({
+    code: 'app.service("Service", function() {});',
+    options: ['eslint', {oldBehavior: false}],
+    errors: [{message: 'The Service service should be prefixed by eslint'}]
+}, {
+    code: 'app.service("esLintService", function() {});',
+    options: ['eslint', {oldBehavior: false}],
+    errors: [{message: 'The esLintService service should be prefixed by eslint'}]
+}, {
+    code: 'app.service("Service", function() {});',
+    options: [/^eslint/, {oldBehavior: false}],
+    errors: [{message: 'The Service service should follow this pattern: /^eslint/'}]
+}, {
+    code: 'app.service("Service", function() {});',
+    options: ['/^eslint/', {oldBehavior: false}],
+    errors: [{message: 'The Service service should follow this pattern: /^eslint/'}]
+}, {
+    code: 'app.service("$Service", function() {});',
+    options: [/^eslint/, {oldBehavior: false}],
+    errors: [{message: 'The $Service service should not start with "$". This is reserved for AngularJS services'}]
+});
+
+
+/**
+ * Old Behaviour
+ */
+
 ['service', 'factory', 'provider', 'constant', 'value'].forEach(function(syntax) {
     valid.push({
         code: 'app.' + syntax + '("eslintService", function() {});',

--- a/test/value-name.js
+++ b/test/value-name.js
@@ -1,0 +1,63 @@
+'use strict';
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+var rule = require('../rules/value-name');
+var RuleTester = require('eslint').RuleTester;
+var commonFalsePositives = require('./utils/commonFalsePositives');
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+var eslintTester = new RuleTester();
+var valid = [];
+var invalid = [];
+
+
+/**
+ * New Behaviour
+ */
+
+valid.push({
+    code: 'app.value("eslintValue", function() {});',
+    options: ['eslint']
+}, {
+    code: 'app.value("eslintValue", function() {});',
+    options: [/^eslint/]
+}, {
+    code: 'app.value("eslintValue", function() {});',
+    options: [undefined]
+}, {
+    code: 'app.value("eslintValue", function() {});',
+    options: ['/^eslint/']
+});
+
+invalid.push({
+    code: 'app.value("Value", function() {});',
+    options: ['eslint'],
+    errors: [{message: 'The Value value should be prefixed by eslint'}]
+}, {
+    code: 'app.value("esLintValue", function() {});',
+    options: ['eslint'],
+    errors: [{message: 'The esLintValue value should be prefixed by eslint'}]
+}, {
+    code: 'app.value("Value", function() {});',
+    options: [/^eslint/],
+    errors: [{message: 'The Value value should follow this pattern: /^eslint/'}]
+}, {
+    code: 'app.value("Value", function() {});',
+    options: ['/^eslint/'],
+    errors: [{message: 'The Value value should follow this pattern: /^eslint/'}]
+}, {
+    code: 'app.value("$Value", function() {});',
+    options: [/^eslint/],
+    errors: [{message: 'The $Value value should not start with "$". This is reserved for AngularJS services'}]
+});
+
+eslintTester.run('value-name', rule, {
+    valid: valid.concat(commonFalsePositives),
+    invalid: invalid
+});


### PR DESCRIPTION
- [x] `service-name` will only apply to services with `oldBehavior` flag
- [x] `isAngularServiceDeclaration` will only apply to `angular.Module#service`
- [x] adding `isAngularFactoryDeclaration` and`factory-name` (same options of `service-name`)
- [x] adding `isAngularProviderDeclaration` and`provider-name` (same options of `service-name`)
- [x] adding `isAngularConstantDeclaration` and`constant-name` (same options of `service-name`)
- [x] adding `isAngularValueDeclaration` and `value-name` (same options of `service-name`)
- [x] `contant-name`
- [x] `value-name`
- [x] `factory-name`
- [x] `provider-name`
- [x] update docs
- [x] warning? (not sure about that)