### PR TITLE
Issue #437 module-dependency-order: allow Identifiers

### DIFF
--- a/docs/module-dependency-order.md
+++ b/docs/module-dependency-order.md
@@ -28,6 +28,11 @@ The following patterns are **not** considered problems with default config;
     // valid
     angular.module('myModule', ['ngAnimate', 'ngRoute', 'app', 'appFilters', 'ui.router']);
 
+    // valid
+    // with ES6 syntax:
+    // import uiRouter from 'angular-ui-router';
+    angular.module('myModule', ['ngAnimate', 'ngRoute', 'app', 'appFilters', uiRouter]);
+
 The following patterns are considered problems when configured `{"grouped":true}`:
 
     /*eslint angular/module-dependency-order: [2,{"grouped":true}]*/

--- a/examples/module-dependency-order.js
+++ b/examples/module-dependency-order.js
@@ -1,6 +1,11 @@
 // example - valid: true
 angular.module('myModule', ['ngAnimate', 'ngRoute', 'app', 'appFilters', 'ui.router']);
 
+// example - valid: true
+// with ES6 syntax:
+// import uiRouter from 'angular-ui-router';
+angular.module('myModule', ['ngAnimate', 'ngRoute', 'app', 'appFilters', uiRouter]);
+
 // example - valid: false, errorMessage: "ngAnimate should be sorted before ngRoute"
 angular.module('myModule', ['ngRoute', 'ngAnimate']);
 

--- a/rules/module-dependency-order.js
+++ b/rules/module-dependency-order.js
@@ -45,9 +45,21 @@ module.exports = function(context) {
         'ngNewRouter'
     ];
 
-    function checkLiteral(node) {
-        if (node && node.type !== 'Literal') {
-            context.report(node, 'Unexpected non-literal value');
+    var moduleName = {
+        Literal: function(node) {
+            return node.value;
+        },
+        Identifier: function(node) {
+            return node.name;
+        }
+    };
+
+    var supportedTypes = Object.keys(moduleName);
+
+    function checkSupportedType(node) {
+        if (node && supportedTypes.indexOf(node.type) === -1) {
+            context.report(node, 'Unexpected node type ' + node.type + '.' +
+                ' Supported node types are: ' + supportedTypes.join(', '));
             return false;
         }
         if (!node) {
@@ -59,10 +71,10 @@ module.exports = function(context) {
     function checkCombined(deps) {
         var lastCorrect;
         deps.elements.forEach(function(node) {
-            if (!checkLiteral(node)) {
+            if (!checkSupportedType(node)) {
                 return;
             }
-            var value = node.value;
+            var value = moduleName[node.type](node);
             if (lastCorrect === undefined || lastCorrect.localeCompare(value) < 0) {
                 lastCorrect = value;
             } else {
@@ -86,10 +98,10 @@ module.exports = function(context) {
         var lastCorrect;
         var group = 'standard';
         deps.elements.forEach(function loop(node) {
-            if (!checkLiteral(node)) {
+            if (!checkSupportedType(node)) {
                 return;
             }
-            var value = node.value;
+            var value = moduleName[node.type](node);
             if (lastCorrect === undefined) {
                 lastCorrect = value;
                 if (isCustomModule(value)) {

--- a/test/module-dependency-order.js
+++ b/test/module-dependency-order.js
@@ -18,16 +18,36 @@ eslintTester.run('module-dependency-order', rule, {
         'angular.module("", [])',
         'angular.module("undefined-dependencies", [,]);',
         'angular.module("")',
-        // combined mode
+        // combined mode, literals only
         {
             code: 'angular.module("", ["app.filters","ngCordova","ngMaterial","ui.router"])',
             options: [{grouped: false}]
         },
-        // grouped mode
+        // combined mode, identifiers only
+        {
+            code: 'angular.module("", [appFilters,ngCordova,ngMaterial,uiRouter])',
+            options: [{grouped: false}]
+        },
+        // combined mode, identifiers & literals mixed
+        {
+            code: 'angular.module("", ["app.filters",ngCordova,ngMaterial,"ui.router"])',
+            options: [{grouped: false}]
+        },
+        // grouped mode, literals only
         'angular.module("", ["ng","ngAnimate","ngAria","ngCookies","ngLocale","ngMaterial","ngMessageFormat","ngMessages","ngMock","ngNewRouter","ngResource","ngRoute","ngSanitize","ngTouch"])',
         'angular.module("", ["ngAnimate","ngResource","ngCordova"])',
         {
             code: 'angular.module("", ["ngAnimate","ngResource","ngCordova","app.filters"])',
+            options: [{prefix: 'app'}]
+        },
+        // grouped mode, identifiers & literals mixed
+        {
+            code: 'angular.module("", [ngAnimate,ngResource,ngCordova,"app.filters"])',
+            options: [{prefix: 'app'}]
+        },
+        // grouped mode, identifiers only
+        {
+            code: 'angular.module("", [ngAnimate,ngResource,ngCordova,appFilters])',
             options: [{prefix: 'app'}]
         }
     ].concat(commonFalsePositives),
@@ -40,10 +60,10 @@ eslintTester.run('module-dependency-order', rule, {
         },
         // combined mode
         {
-            code: 'angular.module("", [dep])',
+            code: 'angular.module("", [dep + \'\'])',
             options: [{grouped: false}],
             errors: [
-                {message: 'Unexpected non-literal value'}
+                {message: 'Unexpected node type BinaryExpression. Supported node types are: Literal, Identifier'}
             ]
         },
         {
@@ -57,9 +77,9 @@ eslintTester.run('module-dependency-order', rule, {
         },
         // grouped mode
         {
-            code: 'angular.module("", [dep])',
+            code: 'angular.module("", [dep + \'\'])',
             errors: [
-                {message: 'Unexpected non-literal value'}
+                {message: 'Unexpected node type BinaryExpression. Supported node types are: Literal, Identifier'}
             ]
         },
         {


### PR DESCRIPTION
This approach is the most liberal one (i.e. it allows identifiers and literals, even mixed, without any configuration). Let's make it a starting point and let's discuss the configuration API it may have.

IMO for backwards compatibility only literal should be allowed by default, but it should be possible to allow Identifiers as well. To disallow mixing them (i.e. to use only Identifiers) one should first disable Literals and then enable Identifiers.

I also made unknown node type message more descriptive.