### PR TITLE
add "casing" option

### DIFF
--- a/rules/file-name.js
+++ b/rules/file-name.js
@@ -105,6 +105,12 @@ module.exports = {
                 if (typeSeparator !== undefined) {
                     name = name + typeSeparator + type;
                 }
+                if (options.casing === 'camel') {
+                    name = filenameUtil.firstToLower(name);
+                }
+                if (options.casing === 'pascal') {
+                    name = filenameUtil.firstToUpper(name);
+                }
                 return name + fileEnding;
             }
         };


### PR DESCRIPTION
add casing to configuration options.  Valid values are "camel" and
"pascal".

Further enhances consistent file naming to closely reflect John Papa's
guidelines.