### PR TITLE
Enhance directive restrict rule to allow split statement for directive registration

### DIFF
--- a/test/directive-restrict.js
+++ b/test/directive-restrict.js
@@ -40,6 +40,25 @@ eslintTester.run('directive-restrict', rule, {
         }, {
             code: 'app.directive("", function() {return {restrict:"E"}})',
             options: [{restrict: 'EA'}]
+        }, {
+            code: `app.directive("snapContainer", ['$scope', myDirective]);
+                function myDirective($scope) {
+                    return {
+                        restrict:   "A"
+                    }
+                }
+            `,
+            options: [{restrict: 'A'}]
+        }, {
+            code: `app.directive("snapContainer", myDirective);
+                /* @ngInject */
+                function myDirective($rootScope) {
+                    return {
+                        restrict:   "A"
+                    }
+                }
+            `,
+            options: [{restrict: 'A'}]
         },
         // Allowed with explicit restrict
         {
@@ -87,6 +106,27 @@ eslintTester.run('directive-restrict', rule, {
             code: 'app.directive("", function() {return {restrict:"E"}})',
             options: [{restrict: 'A'}],
             errors: [{message: 'Disallowed directive restriction. It must be one of A in that order'}]
+        }, {
+            code: `app.directive("snapContainer", ['$scope', myDirective]);
+                function myDirective($scope) {
+                    return {
+                        restrict:   "A"
+                    }
+                }
+            `,
+            options: [{restrict: 'E'}],
+            errors: [{message: 'Disallowed directive restriction. It must be one of E in that order'}]
+        }, {
+            code: `app.directive("snapContainer", myDirective);
+                /* @ngInject */
+                function myDirective($rootScope) {
+                    return {
+                        restrict:   "A"
+                    }
+                }
+            `,
+            options: [{restrict: 'E'}],
+            errors: [{message: 'Disallowed directive restriction. It must be one of E in that order'}]
         },
         // Disallowed with wrong order
         {


### PR DESCRIPTION
Related to issue #494
Enhanced the ``directive-restrict`` rule to support these registration flavours (split statements):

Array notation:
```javascript
app.directive("snapContainer", ['$scope', myDirective]);

function myDirective($scope) {
	return {
		restrict:   "A"
	}
}		
```

Simple notation with ``ngInject``:
```javascript
app.directive("snapContainer", myDirective);
/* @ngInject */
function myDirective($rootScope) {
	return {
		restrict:   "A"
	}
}
```
