### PR TITLE
Add URL to rule documentation to the metadata

### DIFF
--- a/rules/angularelement.js
+++ b/rules/angularelement.js
@@ -12,6 +12,9 @@
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/angularelement.md'
+        },
         schema: []
     },
     create: function(context) {

--- a/rules/avoid-scope-typos.js
+++ b/rules/avoid-scope-typos.js
@@ -17,6 +17,9 @@ const scope = ['scope', '$scope', '$rootScope'];
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/avoid-scope-typos.md'
+        },
         schema: [ ]
     },
     create: function(context) {

--- a/rules/component-limit.js
+++ b/rules/component-limit.js
@@ -20,6 +20,9 @@ var angularRule = require('./utils/angular-rule');
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/component-limit.md'
+        },
         schema: [{
             type: 'integer'
         }]

--- a/rules/component-name.js
+++ b/rules/component-name.js
@@ -15,6 +15,9 @@ var utils = require('./utils/utils');
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/component-name.md'
+        },
         schema: [{
             type: ['string', 'object']
         }]

--- a/rules/constant-name.js
+++ b/rules/constant-name.js
@@ -17,6 +17,9 @@ var utils = require('./utils/utils');
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/constant-name.md'
+        },
         schema: [{
             type: ['string', 'object']
         }, {

--- a/rules/controller-as-route.js
+++ b/rules/controller-as-route.js
@@ -14,6 +14,9 @@ var utils = require('./utils/utils');
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/controller-as-route.md'
+        },
         schema: []
     },
     create: function(context) {

--- a/rules/controller-as-vm.js
+++ b/rules/controller-as-vm.js
@@ -20,6 +20,9 @@ var utils = require('./utils/utils');
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/controller-as-vm.md'
+        },
         schema: [{
             type: 'string'
         }, {

--- a/rules/controller-as.js
+++ b/rules/controller-as.js
@@ -16,6 +16,9 @@ var utils = require('./utils/utils');
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/controller-as.md'
+        },
         schema: [{
             type: ['object', 'string']
         }]

--- a/rules/controller-name.js
+++ b/rules/controller-name.js
@@ -17,6 +17,9 @@ var utils = require('./utils/utils');
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/controller-name.md'
+        },
         schema: [
             {
                 type: 'string'

--- a/rules/deferred.js
+++ b/rules/deferred.js
@@ -13,6 +13,9 @@ var utils = require('./utils/utils');
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/deferred.md'
+        },
         schema: []
     },
     create: function(context) {

--- a/rules/definedundefined.js
+++ b/rules/definedundefined.js
@@ -18,6 +18,9 @@ const SHOULD_NOT_USE_BANG_WITH_ISUNDEFINED = 'Instead of !angular.isUndefined, y
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/definedundefined.md'
+        },
         schema: [],
         fixable: 'code'
     },

--- a/rules/di-order.js
+++ b/rules/di-order.js
@@ -16,6 +16,9 @@ var caseSensitive = 'case_sensitive';
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/di-order.md'
+        },
         schema: [{
             type: 'boolean'
         }, {

--- a/rules/di-unused.js
+++ b/rules/di-unused.js
@@ -14,6 +14,9 @@ var angularRule = require('./utils/angular-rule');
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/di-unused.md'
+        },
         schema: []
     },
     create: angularRule(function(context) {

--- a/rules/di.js
+++ b/rules/di.js
@@ -16,6 +16,9 @@ var angularRule = require('./utils/angular-rule');
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/di.md'
+        },
         schema: [{
             enum: [
                 'function',

--- a/rules/directive-name.js
+++ b/rules/directive-name.js
@@ -17,6 +17,9 @@ var utils = require('./utils/utils');
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/directive-name.md'
+        },
         schema: [{
             type: ['string', 'object']
         }]

--- a/rules/directive-restrict.js
+++ b/rules/directive-restrict.js
@@ -17,6 +17,9 @@ var utils = require('./utils/utils');
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/directive-restrict.md'
+        },
         schema: [{
             type: 'object',
             properties: {

--- a/rules/document-service.js
+++ b/rules/document-service.js
@@ -12,6 +12,9 @@
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/document-service.md'
+        },
         schema: []
     },
     create: function(context) {

--- a/rules/dumb-inject.js
+++ b/rules/dumb-inject.js
@@ -15,6 +15,9 @@ var angularRule = require('./utils/angular-rule');
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/dumb-inject.md'
+        },
         schema: []
     },
     create: angularRule(function(context) {

--- a/rules/empty-controller.js
+++ b/rules/empty-controller.js
@@ -14,6 +14,9 @@ var utils = require('./utils/utils');
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/empty-controller.md'
+        },
         schema: []
     },
     create: function(context) {

--- a/rules/factory-name.js
+++ b/rules/factory-name.js
@@ -17,6 +17,9 @@ var utils = require('./utils/utils');
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/factory-name.md'
+        },
         schema: [{
             type: ['string', 'object']
         }, {

--- a/rules/file-name.js
+++ b/rules/file-name.js
@@ -57,6 +57,9 @@ function handleModuleCase(node, context, defaultFilename) {
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/file-name.md'
+        },
         schema: [{
             type: ['object']
         }]

--- a/rules/filter-name.js
+++ b/rules/filter-name.js
@@ -15,6 +15,9 @@ var utils = require('./utils/utils');
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/filter-name.md'
+        },
         schema: [{
             type: ['string', 'object']
         }]

--- a/rules/foreach.js
+++ b/rules/foreach.js
@@ -11,6 +11,9 @@
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/foreach.md'
+        },
         schema: []
     },
     create: function(context) {

--- a/rules/function-type.js
+++ b/rules/function-type.js
@@ -17,6 +17,9 @@ var utils = require('./utils/utils');
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/function-type.md'
+        },
         schema: [{
             enum: [
                 'named',

--- a/rules/interval-service.js
+++ b/rules/interval-service.js
@@ -12,6 +12,9 @@
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/interval-service.md'
+        },
         schema: []
     },
     create: function(context) {

--- a/rules/json-functions.js
+++ b/rules/json-functions.js
@@ -12,6 +12,9 @@
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/json-functions.md'
+        },
         schema: []
     },
     create: function(context) {

--- a/rules/log.js
+++ b/rules/log.js
@@ -10,6 +10,9 @@
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/log.md'
+        },
         schema: []
     },
     create: function(context) {

--- a/rules/module-dependency-order.js
+++ b/rules/module-dependency-order.js
@@ -19,6 +19,9 @@ var utils = require('./utils/utils');
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/module-dependency-order.md'
+        },
         schema: [{
             type: 'object',
             properties: {

--- a/rules/module-getter.js
+++ b/rules/module-getter.js
@@ -15,6 +15,9 @@ var utils = require('./utils/utils');
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/module-getter.md'
+        },
         schema: []
     },
     create: function(context) {

--- a/rules/module-name.js
+++ b/rules/module-name.js
@@ -16,6 +16,9 @@ var utils = require('./utils/utils');
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/module-name.md'
+        },
         schema: [{
             type: ['string', 'object']
         }]

--- a/rules/module-setter.js
+++ b/rules/module-setter.js
@@ -15,6 +15,9 @@ var utils = require('./utils/utils');
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/module-setter.md'
+        },
         schema: []
     },
     create: function(context) {

--- a/rules/no-angular-mock.js
+++ b/rules/no-angular-mock.js
@@ -32,6 +32,9 @@
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/no-angular-mock.md'
+        },
         schema: []
     },
     create: function(context) {

--- a/rules/no-controller.js
+++ b/rules/no-controller.js
@@ -13,6 +13,9 @@ var utils = require('./utils/utils');
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/no-controller.md'
+        },
         schema: []
     },
     create: function(context) {

--- a/rules/no-cookiestore.js
+++ b/rules/no-cookiestore.js
@@ -12,6 +12,9 @@
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/no-cookiestore.md'
+        },
         schema: []
     },
     create: function(context) {

--- a/rules/no-directive-replace.js
+++ b/rules/no-directive-replace.js
@@ -16,6 +16,9 @@ var angularRule = require('./utils/angular-rule');
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/no-directive-replace.md'
+        },
         schema: [{
             type: 'object',
             properties: {

--- a/rules/no-http-callback.js
+++ b/rules/no-http-callback.js
@@ -12,6 +12,9 @@
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/no-http-callback.md'
+        },
         schema: []
     },
     create: function(context) {

--- a/rules/no-inline-template.js
+++ b/rules/no-inline-template.js
@@ -13,6 +13,9 @@
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/no-inline-template.md'
+        },
         schema: [{
             allowSimple: {
                 type: 'boolean'

--- a/rules/no-jquery-angularelement.js
+++ b/rules/no-jquery-angularelement.js
@@ -10,6 +10,9 @@
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/no-jquery-angularelement.md'
+        },
         schema: []
     },
     create: function(context) {

--- a/rules/no-private-call.js
+++ b/rules/no-private-call.js
@@ -13,6 +13,9 @@
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/no-private-call.md'
+        },
         schema: [
             {
                 type: 'object',

--- a/rules/no-run-logic.js
+++ b/rules/no-run-logic.js
@@ -15,6 +15,9 @@ var angularRule = require('./utils/angular-rule');
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/no-run-logic.md'
+        },
         schema: [{
             type: 'object',
             properties: {

--- a/rules/no-service-method.js
+++ b/rules/no-service-method.js
@@ -14,6 +14,9 @@ var utils = require('./utils/utils');
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/no-service-method.md'
+        },
         schema: []
     },
     create: function(context) {

--- a/rules/no-services.js
+++ b/rules/no-services.js
@@ -17,6 +17,9 @@ const utils = require('./utils/utils');
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/no-services.md'
+        },
         schema: [{
             type: ['array', 'object']
         }, {

--- a/rules/on-destroy.js
+++ b/rules/on-destroy.js
@@ -10,6 +10,9 @@
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/on-destroy.md'
+        },
         schema: []
     },
     create: function(context) {

--- a/rules/on-watch.js
+++ b/rules/on-watch.js
@@ -10,6 +10,9 @@
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/on-watch.md'
+        },
         schema: []
     },
     create: function(context) {

--- a/rules/one-dependency-per-line.js
+++ b/rules/one-dependency-per-line.js
@@ -13,6 +13,9 @@ var utils = require('./utils/utils');
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/one-dependency-per-line.md'
+        },
         schema: []
     },
     create: function(context) {

--- a/rules/prefer-component.js
+++ b/rules/prefer-component.js
@@ -13,6 +13,9 @@ var allowedProperties = ['compile', 'link', 'multiElement', 'priority', 'templat
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/prefer-component.md'
+        },
         schema: []
     },
     create: angularRule(function(context) {

--- a/rules/provider-name.js
+++ b/rules/provider-name.js
@@ -17,6 +17,9 @@ var utils = require('./utils/utils');
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/provider-name.md'
+        },
         schema: [{
             type: ['string', 'object']
         }, {

--- a/rules/rest-service.js
+++ b/rules/rest-service.js
@@ -14,6 +14,9 @@ const utils = require('./utils/utils');
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/rest-service.md'
+        },
         schema: [{
             type: 'string'
         }]

--- a/rules/service-name.js
+++ b/rules/service-name.js
@@ -75,6 +75,9 @@ function warnForDeprecatedBehavior(options) {
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/service-name.md'
+        },
         schema: [{
             type: ['string', 'object']
         }, {

--- a/rules/timeout-service.js
+++ b/rules/timeout-service.js
@@ -12,6 +12,9 @@
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/timeout-service.md'
+        },
         schema: []
     },
     create: function(context) {

--- a/rules/typecheck-array.js
+++ b/rules/typecheck-array.js
@@ -13,6 +13,9 @@ var utils = require('./utils/utils');
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/typecheck-array.md'
+        },
         schema: []
     },
     create: function(context) {

--- a/rules/typecheck-date.js
+++ b/rules/typecheck-date.js
@@ -13,6 +13,9 @@ var utils = require('./utils/utils');
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/typecheck-date.md'
+        },
         schema: []
     },
     create: function(context) {

--- a/rules/typecheck-function.js
+++ b/rules/typecheck-function.js
@@ -13,6 +13,9 @@ var utils = require('./utils/utils');
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/typecheck-function.md'
+        },
         schema: []
     },
     create: function(context) {

--- a/rules/typecheck-number.js
+++ b/rules/typecheck-number.js
@@ -13,6 +13,9 @@ var utils = require('./utils/utils');
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/typecheck-number.md'
+        },
         schema: []
     },
     create: function(context) {

--- a/rules/typecheck-object.js
+++ b/rules/typecheck-object.js
@@ -13,6 +13,9 @@ var utils = require('./utils/utils');
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/typecheck-object.md'
+        },
         schema: []
     },
     create: function(context) {

--- a/rules/typecheck-string.js
+++ b/rules/typecheck-string.js
@@ -13,6 +13,9 @@ var utils = require('./utils/utils');
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/typecheck-string.md'
+        },
         schema: []
     },
     create: function(context) {

--- a/rules/value-name.js
+++ b/rules/value-name.js
@@ -17,6 +17,9 @@ var utils = require('./utils/utils');
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/value-name.md'
+        },
         schema: [{
             type: ['string', 'object']
         }]

--- a/rules/watchers-execution.js
+++ b/rules/watchers-execution.js
@@ -12,6 +12,9 @@
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/watchers-execution.md'
+        },
         schema: [{
             enum: ['$apply', '$digest']
         }]

--- a/rules/window-service.js
+++ b/rules/window-service.js
@@ -12,6 +12,9 @@
 
 module.exports = {
     meta: {
+        docs: {
+            url: 'https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/rules/window-service.md'
+        },
         schema: []
     },
     create: function(context) {


### PR DESCRIPTION
ESLint v4.15.0 added an official location for rules to store a URL to their documentation in the rule metadata in https://github.com/eslint/eslint/pull/9788. This adds the URL to all the existing rules so anything consuming them can know where their documentation is without having to resort to external packages to guess.