### PR TITLE
Ensure that fn.params is defined.

### DIFF
--- a/rules/di.js
+++ b/rules/di.js
@@ -67,7 +67,7 @@ module.exports = {
         }
 
         function checkDi(callee, fn) {
-            if (!fn) {
+            if (!fn || !fn.params) {
                 return;
             }
 


### PR DESCRIPTION
Without this, eslint may throw `TypeError: Cannot read property 'length' of undefined` on otherwise valid files.