### PR TITLE
Implement regexp for file name rule

### DIFF
--- a/docs/rules/file-name.md
+++ b/docs/rules/file-name.md
@@ -6,6 +6,7 @@ All your file names should match the angular component name.
 The second parameter can be a config object [2, {nameStyle: 'dash', typeSeparator: 'dot', ignoreTypeSuffix: true, ignorePrefix: 'ui'}] to match 'avenger-profile.directive.js' or 'avanger-api.service.js'.
 Possible values for 'typeSeparator' and 'nameStyle' are 'dot', 'dash' and 'underscore'.
 The options 'ignoreTypeSuffix' ignores camel cased suffixes like 'someController' or 'myService' and 'ignorePrefix' ignores namespace prefixes like 'ui'.
+It's possible to specify a regexp for ignorePrefix. Example RegExp: "/^ui./".
 
 The naming scheme is &lt;componentName&gt;&lt;typeSeparator&gt;&lt;componentType&gt;.js
 
@@ -126,6 +127,13 @@ The following patterns are **not** considered problems when configured `{"typeSe
 
     // valid with filename: src/app/userUtils.service.js
     angular.factory('ui.UserUtils', uiUserUtils);
+
+    // valid with filename: src/app/utils.module.js
+    angular.module('ui.utils', function(){});
+
+The following patterns are **not** considered problems when configured `{"typeSeparator":"dot","ignorePrefix":"/^ui./"}`:
+
+    /*eslint angular/file-name: [2,{"typeSeparator":"dot","ignorePrefix":"/^ui./"}]*/
 
     // valid with filename: src/app/utils.module.js
     angular.module('ui.utils', function(){});

--- a/examples/file-name.js
+++ b/examples/file-name.js
@@ -60,6 +60,9 @@ angular.factory('ui.UserUtils', uiUserUtils);
 // example - valid: true, options: [{"typeSeparator":"dot", "ignorePrefix": "ui."}], filename: "src/app/utils.module.js"
 angular.module('ui.utils', function(){});
 
+// example - valid: true, options: [{"typeSeparator":"dot", "ignorePrefix": "/^ui./"}], filename: "src/app/utils.module.js"
+angular.module('ui.utils', function(){});
+
 
 // example - valid: true, options: [{"typeSeparator":"dot", "componentTypeMappings": {"factory": "factory", "provider": "provider"}}], filename: "src/app/users.factory.js"
 angular.factory('users', function(){});

--- a/rules/file-name.js
+++ b/rules/file-name.js
@@ -109,6 +109,10 @@ module.exports = {
                 return name;
             },
             removePrefix: function(name, options) {
+                if (utils.isStringRegexp(options.ignorePrefix)) {
+                    return this.firstToLower(name.replace(utils.convertStringToRegex(options.ignorePrefix), ''));
+                }
+
                 var regName = '^' + options.ignorePrefix.replace(/[\.]/g, '\\$&');
                 regName += options.ignorePrefix.indexOf('\.') === -1 ? '[A-Z]' : '[a-zA-z]';
                 if (new RegExp(regName).test(name)) {

--- a/rules/file-name.js
+++ b/rules/file-name.js
@@ -5,6 +5,7 @@
  * The second parameter can be a config object [2, {nameStyle: 'dash', typeSeparator: 'dot', ignoreTypeSuffix: true, ignorePrefix: 'ui'}] to match 'avenger-profile.directive.js' or 'avanger-api.service.js'.
  * Possible values for 'typeSeparator' and 'nameStyle' are 'dot', 'dash' and 'underscore'.
  * The options 'ignoreTypeSuffix' ignores camel cased suffixes like 'someController' or 'myService' and 'ignorePrefix' ignores namespace prefixes like 'ui'.
+ * It's possible to specify a regexp for ignorePrefix. Example RegExp: "/^ui./".
  *
  * The naming scheme is &lt;componentName&gt;&lt;typeSeparator&gt;&lt;componentType&gt;.js
  *

--- a/rules/utils/utils.js
+++ b/rules/utils/utils.js
@@ -110,7 +110,7 @@ function convertPrefixToRegex(prefix) {
  */
 function convertStringToRegex(string) {
     if (string[0] === '/' && string[string.length - 1] === '/') {
-        string = string.substring(1, string.length - 2);
+        string = string.substring(1, string.length - 1);
     }
     return new RegExp(string);
 }

--- a/test/file-name.js
+++ b/test/file-name.js
@@ -275,6 +275,15 @@ angular.module(mod, [mod + '.core.angular', mod + '.thirdparty']);
             ecmaVersion: 6,
             sourceType: 'module'
         }
+    }, {
+        // RegExp case
+        filename: 'src/app/regexp.service.js',
+        code: 'app.factory("epaRegexpService", function() {});',
+        options: [{
+            typeSeparator: 'dot',
+            ignoreTypeSuffix: true,
+            ignorePrefix: '/^epa/'
+        }]
     }].concat(commonFalsePositives),
     invalid: [{
         filename: 'src/app/filters.js',
@@ -469,6 +478,18 @@ angular.module(mod, [mod + '.core.angular', mod + '.thirdparty']);
         },
         errors: [{
             message: 'Filename must be "SomeController.js"'
+        }]
+    }, {
+        // RegExp case
+        filename: 'src/app/Regexp.service.js',
+        code: 'app.factory("epaRegexpService", function() {});',
+        options: [{
+            typeSeparator: 'dot',
+            ignoreTypeSuffix: true,
+            ignorePrefix: '/^epa/'
+        }],
+        errors: [{
+            message: 'Filename must be "regexp.service.js"'
         }]
     }]
 });


### PR DESCRIPTION
Solves issue: #534 

This PR will make it possible to use regexp in the ignorePrefix option for the file-name rule.
This is because people want to have custom ignoring,

Examples:
Ignore multiple prefixes.
Change the ignoring for modules.