### PR TITLE
Fix arrow function problem no directive replace

### DIFF
--- a/rules/no-directive-replace.js
+++ b/rules/no-directive-replace.js
@@ -52,25 +52,21 @@ module.exports = {
                     return;
                 }
 
-                var body = fnNode.type === 'ArrowFunctionExpression' ? [fnNode.body] : fnNode.body.body;
+                var body = fnNode.body.body ? fnNode.body.body : [fnNode.body];
 
                 body.forEach(function(statement) {
                     if (statement.type === 'ReturnStatement' || statement.type === 'ObjectExpression') {
-                        var name = statement.name;
-                        if (statement.type === 'ReturnStatement') {
-                            name = statement.argument.name;
+                        // get potential replace node by argument name of empty string for object expressions
+                        var potentialNodes = potentialReplaceNodes[''];
+                        if (statement.argument) {
+                            potentialNodes = potentialReplaceNodes[statement.argument.name || ''];
                         }
 
-                        // get potential replace node by argument name of empty string for object expressions
-                        var potentialNodes = potentialReplaceNodes[name || ''];
                         if (!potentialNodes) {
                             return;
                         }
                         potentialNodes.forEach(function(report) {
-                            var block = statement.parent;
-                            if (block.type === 'ArrowFunctionExpression') {
-                                block = statement;
-                            }
+                            var block = statement.parent.type === 'ArrowFunctionExpression' ? statement : statement.parent;
 
                             // only reports nodes that belong to the same expression
                             if (report.block === block) {

--- a/test/no-directive-replace.js
+++ b/test/no-directive-replace.js
@@ -12,17 +12,23 @@ var commonFalsePositives = require('./utils/commonFalsePositives');
 // Tests
 // ------------------------------------------------------------------------------
 
-var eslintTester = new RuleTester();
+var eslintTester = new RuleTester({
+    parserOptions: {
+        ecmaVersion: 6
+    }
+});
 eslintTester.run('no-directive-replace', rule, {
     valid: [
         'angular.module("").factory("", function() {return {replace: false}})',
         'angular.module("").directive("")',
         'angular.module("").directive()',
         'angular.module("").directive("", function() {})',
+        'angular.module("").directive("", () => ({}))',
         'angular.module("").directive("", function() {return {anotherProperty:"anotherValue"}})',
         'angular.module("").directive("", function() {return {restrict:"A"}})',
         'angular.module("").directive("", function() { var def = {}; return def; })',
         'angular.module("").directive("", function() { function x() { return {replace: true} }; x(); return {}; })',
+        'angular.module("").directive("", function() { () => ({replace: true}); return {}; })',
 
         'angular.module("").directive("", function() { var def = {}; def.otherProperty = true; return def; })',
         'angular.module("").directive("", function() { var nonDef = {replace: true}; return {}; })',
@@ -40,6 +46,10 @@ eslintTester.run('no-directive-replace', rule, {
         // Disallowed with default configuration
         {
             code: 'angular.module("").directive("", function() {return {replace:true}})',
+            errors: [{message: 'Directive definition property replace is deprecated.'}]
+        },
+        {
+            code: 'angular.module("").directive("", () => ({replace:true}))',
             errors: [{message: 'Directive definition property replace is deprecated.'}]
         },
         {


### PR DESCRIPTION
Fix #541 

This case below caused a crash in the plugin.

```
angular.
module('contact.contactShow.dashboardSite').
directive('siteDashboard', () => ({replace:true})
);

angular.
module('contact.contactShow.dashboardSite').
directive('siteDashboard', function () {() => ({replace:true}); return {replace:true}}
);

angular.
module("dsds").
directive('siteDashboard', function SiteDashboardDirective () {
    return {
        template,
        restrict: 'E',
        scope: true,
        replace:true
    };
});
```

I had to add ecmascript version 6 to the RuleTester to being able to add test cases with arrow function without getting parsing error.

I have no idea if the plugin should support this version of ecmascript and if this is the optimal solution for this kind of problem.

You can use the test code above to see that it's working and that it's failing prior to the fix.