### PR TITLE
Change default function-type rule option to prefer named functions

### DIFF
--- a/rules/function-type.js
+++ b/rules/function-type.js
@@ -34,7 +34,7 @@ module.exports = {
     },
     create: function(context) {
         var angularObjectList = ['animation', 'config', 'constant', 'controller', 'directive', 'factory', 'filter', 'provider', 'service', 'value', 'decorator'];
-        var configType = context.options[0] || 'anonymous';
+        var configType = context.options[0] || 'named';
         var messageByConfigType = {
             anonymous: 'Use anonymous functions instead of named function',
             named: 'Use named functions instead of anonymous function'

--- a/test/function-type.js
+++ b/test/function-type.js
@@ -58,6 +58,9 @@ valid.push({
     code: 'angular.module("foo", []).constant("foo", (() => {})())',
     options: ['anonymous'],
     parserOptions: {ecmaVersion: 6}
+}, {
+    code: 'var foo = "foo";angular.module("foo", []).constant("foo", foo)',
+    options: ['named']
 });
 
 

--- a/test/utils/commonFalsePositives.js
+++ b/test/utils/commonFalsePositives.js
@@ -11,5 +11,5 @@ module.exports = [
     'mocha.run();',
     'controller = el.controller();',
     {code: 'angular.module("m", [])', filename: 'm.js'},
-    {code: 'angular.module("").factory("s", function () {});', filename: 's.js'}
+    {code: 'var s = function () {};angular.module("").factory("s", s);', filename: 's.js'}
 ];


### PR DESCRIPTION
Hello,

These changes alter the default option used by the `angular/function-type` rule so that named functions are preferred over anonymous ones. This alteration is in line with John Papa's style guidance for AngularJS ([Y024][]).

Also had to fiddle with the test suite a bit to ensure it stayed green.

[Y024]: https://github.com/johnpapa/angular-styleguide/tree/master/a1#style-y024