### PR TITLE
Add support for enforcing angular.mock.module

### DIFF
--- a/docs/rules/no-angular-mock.md
+++ b/docs/rules/no-angular-mock.md
@@ -9,7 +9,7 @@ So you can remove angular.mock from your code
 
 ## Examples
 
-The following patterns are considered problems;
+The following patterns are considered problems with default config;
 
     /*eslint angular/no-angular-mock: 2*/
 
@@ -24,7 +24,7 @@ The following patterns are considered problems;
     // invalid
     angular.mock.module('myModule'); // error: You should use the "module" method available in the window object.
 
-The following patterns are **not** considered problems;
+The following patterns are **not** considered problems with default config;
 
     /*eslint angular/no-angular-mock: 2*/
 
@@ -38,6 +38,26 @@ The following patterns are **not** considered problems;
 
     // valid
     module('myModule');
+
+The following patterns are considered problems when configured `"webpack-module-support"`:
+
+    /*eslint angular/no-angular-mock: [2,"webpack-module-support"]*/
+
+    // invalid
+    module('myModule'); // error: You should use the "angular.mock.module" method directly.
+
+The following patterns are **not** considered problems when configured `"webpack-module-support"`:
+
+    /*eslint angular/no-angular-mock: [2,"webpack-module-support"]*/
+
+    // valid
+    inject();
+
+    // valid
+    dump();
+
+    // valid
+    angular.mock.module('myModule');
 
 ## Version
 

--- a/examples/no-angular-mock.js
+++ b/examples/no-angular-mock.js
@@ -19,3 +19,15 @@ angular.mock.inject(function (someService) {
 
 // example - valid: false, errorMessage: "You should use the \"module\" method available in the window object."
 angular.mock.module('myModule');
+
+// example - valid: true, options: ["webpack-module-support"]
+inject();
+
+// example - valid: true, options: ["webpack-module-support"]
+dump();
+
+// example - valid: true, options: ["webpack-module-support"]
+angular.mock.module('myModule');
+
+// example - valid: false, options: ["webpack-module-support"], errorMessage: "You should use the \"angular.mock.module\" method directly."
+module('myModule');

--- a/test/no-angular-mock.js
+++ b/test/no-angular-mock.js
@@ -17,17 +17,61 @@ eslintTester.run('no-angular-mock', rule, {
     valid: [
         'dump();',
         'inject();',
-        'module();'
+        'module();',
+        'module',
+        'module.exports',
+        'module.exports = {}',
+        {
+            code: 'dump()',
+            options: ['webpack-module-support']
+        }
     ].concat(commonFalsePositives),
     invalid: [{
         code: 'angular.mock.dump();',
-        errors: [{message: 'You should use the "dump" method available in the window object.'}]
+        errors: [{message: 'You should use the "dump" method available in the window object.'}],
+        output: 'dump();'
     }, {
         code: 'angular.mock.inject();',
-        errors: [{message: 'You should use the "inject" method available in the window object.'}]
+        errors: [{message: 'You should use the "inject" method available in the window object.'}],
+        output: 'inject();'
     }, {
         code: 'angular.mock.module();',
-        errors: [{message: 'You should use the "module" method available in the window object.'}]
+        errors: [{message: 'You should use the "module" method available in the window object.'}],
+        output: 'module();'
+    }, {
+        code: 'beforeEach(angular.mock.module("exampleModule"))',
+        errors: [{message: 'You should use the "module" method available in the window object.'}],
+        output: 'beforeEach(module("exampleModule"))'
+    }, {
+        code: 'angular.mock.dump();',
+        options: ['webpack-module-support'],
+        errors: [{message: 'You should use the "dump" method available in the window object.'}],
+        output: 'dump();'
+    }, {
+        code: 'angular.mock.inject();',
+        options: ['webpack-module-support'],
+        errors: [{message: 'You should use the "inject" method available in the window object.'}],
+        output: 'inject();'
+    }, {
+        code: 'module();',
+        options: ['webpack-module-support'],
+        errors: [{message: 'You should use the "angular.mock.module" method directly.'}],
+        output: 'angular.mock.module();'
+    }, {
+        code: 'module("exampleModule");',
+        options: ['webpack-module-support'],
+        errors: [{message: 'You should use the "angular.mock.module" method directly.'}],
+        output: 'angular.mock.module("exampleModule");'
+    }, {
+        code: 'beforeEach(module("exampleModule"))',
+        options: ['webpack-module-support'],
+        errors: [{message: 'You should use the "angular.mock.module" method directly.'}],
+        output: 'beforeEach(angular.mock.module("exampleModule"))'
+    }, {
+        code: 'angular.mock.module("exampleModule"); module("anotherModule")',
+        options: ['webpack-module-support'],
+        errors: [{message: 'You should use the "angular.mock.module" method directly.'}],
+        output: 'angular.mock.module("exampleModule"); angular.mock.module("anotherModule")'
     }
     ]
 });


### PR DESCRIPTION
This is needed when migrating angular.js to use webpack, and the existing unit tests call `module('myModule')`. This causes problems as `module` is a reserved/special word for webpack use, and the unit tests won't compile (complaining that `module is not a function`). The solution is to use `angular.mock.module('myModule')`. This rule change adds a `webpack-support` option (open to renaming this), and adds a fixer that can sort out the problems found (to save on Ctrl+F'ing through the code and finding issues).

Please see the following for more context/examples:
https://stackoverflow.com/questions/32499108/karma-jasmine-webpack-module-is-not-a-function
https://stackoverflow.com/questions/39360164/module-is-not-a-function-karma-jasmine-webpack-angular?rq=1